### PR TITLE
Fixes FilteredTimeStepper tests

### DIFF
--- a/src/timesteppers.jl
+++ b/src/timesteppers.jl
@@ -1,8 +1,6 @@
 __precompile__()
 
 
-
-
 export ForwardEulerTimeStepper, FilteredForwardEulerTimeStepper,
        AB3TimeStepper,
        RK4TimeStepper,
@@ -113,12 +111,11 @@ type FilteredForwardEulerTimeStepper{dim} <: AbstractTimeStepper
   step::Int
   dt::Float64
   NL::Array{Complex{Float64}, dim}        # Nonlinear term
-  filter::Array{Complex{Float64}, dim}    # Filter for solution
+  filter::Array{Float64, dim}    # Filter for solution
 end
 
 function FilteredForwardEulerTimeStepper(dt::Float64, g::AbstractGrid,
   sol::AbstractArray; filterorder=4.0, innerfilterK=0.65, outerfilterK=0.95)
-
   NL = zeros(sol)
 
   if size(sol)[1] == g.nkr
@@ -131,14 +128,13 @@ function FilteredForwardEulerTimeStepper(dt::Float64, g::AbstractGrid,
     outerK=outerfilterK, realvars=realvars)
 
   # Broadcast to correct size
-  filter = ones(sol) .* filter
+  filter = ones(real.(sol)) .* filter
 
   FilteredForwardEulerTimeStepper{ndims(NL)}(0, dt, NL, filter)
 end
 
 function FilteredForwardEulerTimeStepper(dt::Float64, g::AbstractGrid,
   v::AbstractVars; filterorder=4.0, innerfilterK=0.65, outerfilterK=0.95)
-
   FilteredForwardEulerTimeStepper(dt, g, v.sol; filterorder=filterorder,
     innerfilterK=innerfilterK, outerfilterK=outerfilterK)
 end
@@ -272,7 +268,7 @@ function FilteredETDRK4TimeStepper(dt::Float64, LC::AbstractArray,
     outerK=outerfilterK, realvars=realvars)
 
   # Broadcast to correct size
-  filter = ones(LC) .* filter
+  filter = ones(real.(LC)) .* filter
 
   FilteredETDRK4TimeStepper{ndims(LC)}(0, dt, LC, zeta, alph, beta, gamm,
         expLCdt, expLCdt2, ti, sol1, sol2, NL1, NL2, NL3, NL4, filter)

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -12,13 +12,18 @@ end
 function teststepforward(g, p, v, eq; dt=1e-16, nsteps=10,
   stepper="ForwardEuler")
 
-  ts = FilteredForwardEulerTimeStepper(dt, g, v; filterorder=4.0, innerfilterK=0.4, outerfilterK=1)
-  filter = ts.filter
+  filter = ones(v.sol)
+  if stepper == "FiltrForwardEuler" || stepper == "FiltrETDRK4"
+      # create a filtered ts (simpler is Euler)
+      ts = FilteredForwardEulerTimeStepper(dt, g, v; filterorder=4.0, innerfilterK=0.65, outerfilterK=1)
+      # and use its filter to apply it to the initial condition
+      filter = ts.filter
+  end
 
   if stepper == "ForwardEuler"
       ts = ForwardEulerTimeStepper(dt, eq.LC)
   elseif stepper == "FiltrForwardEuler"
-      ts = FilteredForwardEulerTimeStepper(dt, g, v)
+      ts = FilteredForwardEulerTimeStepper(dt, g, v; filterorder=4.0, innerfilterK=0.65, outerfilterK=1)
   elseif stepper == "AB3"
       ts = AB3TimeStepper(dt, eq.LC)
   elseif stepper == "RK4"
@@ -29,26 +34,27 @@ function teststepforward(g, p, v, eq; dt=1e-16, nsteps=10,
       ts = FilteredETDRK4TimeStepper(dt, eq.LC, g)
   end
 
-  # qi = rand(g.nx, g.ny)
-  # qi = sin.(3*g.X).*sin.(2*g.Y) + 2*sin.(1*g.X).*sin.(4*g.Y)
-  # qi = qi-mean(qi)
-  # if stepper == "FiltrForwardEuler" || stepper == "FiltrETDRK4"
-  #   qi = irfft(rfft(qi).*ts.filter, g.nx)
-  # end
-
-
-  qih = (randn(g.nkr, g.nl)+im*randn(g.nkr, g.nl)).*filter
-  qih[1, 1]=0
-  qi = irfft(qih, g.nx)
+  # the initial conditions (IC)
+  qi = randn(g.nx, g.ny)
+  qi = qi-mean(qi)
+  qih_copy = rfft(qi).*filter
+  # the following removes power from IC from wavenumbers larger than 0.3*kmax
+  # (this is needed for the filtered time-steppers to give machine precision
+  # during the tests)
+  qih_copy[sqrt.( (g.Kr*g.dx/π).^2  + (g.Lr*g.dy/π).^2) .> 0.3]=0
+  qi = irfft(qih_copy, g.nx)
+  qih = rfft(qi)
 
   prob = Problem(g, v, p, eq, ts)
   TwoDTurb.set_q!(prob, qi)
 
   absq₀ = sum(abs.(prob.vars.sol))
+
   stepforward!(prob; nsteps=nsteps)
+
   absq₁ = sum(abs.(prob.vars.sol))
 
-  isapprox(absq₀, absq₁, atol=nsteps*g.nx*g.ny*1e-15)
+  isapprox(absq₀, absq₁, rtol=nsteps*1e-14)
 end
 
 function teststepforward(n::Int, L, ν, nν::Int; stepper="ForwardEuler")
@@ -57,8 +63,8 @@ function teststepforward(n::Int, L, ν, nν::Int; stepper="ForwardEuler")
 end
 
 @test teststepforward(128, 2π, 1e-2, 2; stepper="ForwardEuler")
-# @test teststepforward(128, 2π, 1e-2, 2; stepper="FiltrForwardEuler")
+@test teststepforward(128, 2π, 1e-2, 2; stepper="FiltrForwardEuler")
 @test teststepforward(128, 2π, 1e-2, 2; stepper="AB3")
 @test teststepforward(128, 2π, 1e-2, 2; stepper="RK4")
 @test teststepforward(128, 2π, 1e-2, 2; stepper="ETDRK4")
-# @test teststepforward(128, 2π, 1e-2, 2; stepper="FiltrETDRK4")
+@test teststepforward(128, 2π, 1e-2, 2; stepper="FiltrETDRK4")


### PR DESCRIPTION
The fix was to use an initial condition with spectral power only for wavenumbers less than, e.g., 0.3*kmax. This way the FilteredTimeSteppers give machine precision accuracy when stepped forward for 10 time-steps of dt=1e-16.