### PR TITLE
CalcN refactor

### DIFF
--- a/src/physics/barotropicqg.jl
+++ b/src/physics/barotropicqg.jl
@@ -88,24 +88,24 @@ end
 # E Q U A T I O N S -----------------------------------------------------------
 type Equation <: AbstractEquation
   LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's linear part
-  calcNL!::Function               # Function to calculate eqn's nonlinear part
+  calcN!::Function               # Function to calculate eqn's nonlinear part
 end
 
 function Equation(p::Params, g::TwoDGrid)
   LC = -p.mu - p.nu.*g.KKrsq.^(0.5*p.nun)
-  Equation(LC, calcNL!)
+  Equation(LC, calcN!)
 end
 
 function Equation(p::ConstMeanParams, g::TwoDGrid)
-  # Function calcNL! is defined below.
+  # Function calcN! is defined below.
   LC = -p.mu - p.nu.*g.KKrsq.^(0.5*p.nun)
-  Equation(LC, calc_const_mean_NL!)
+  Equation(LC, calc_const_mean_N!)
 end
 
 function Equation(p::FreeDecayParams, g::TwoDGrid)
-  # Function calcNL! is defined below.
+  # Function calcN! is defined below.
   LC = -p.mu - p.nu.*g.KKrsq.^(0.5*p.nun)
-  Equation(LC, calc_free_decay_NL!)
+  Equation(LC, calc_free_decay_N!)
 end
 
 
@@ -231,7 +231,7 @@ end
 
 # S O L V E R S ---------------------------------------------------------------
 
-function calcNL!(NL::Array{Complex{Float64}, 2}, sol::Array{Complex{Float64}, 2},
+function calcN!(N::Array{Complex{Float64}, 2}, sol::Array{Complex{Float64}, 2},
   t::Float64, v::Vars, p::Params, g::TwoDGrid)
   # Calculate the nonlinear part of two equations: one 2D equation
   # governing the evolution of a barotropic QG flow, and a single
@@ -258,16 +258,16 @@ function calcNL!(NL::Array{Complex{Float64}, 2}, sol::Array{Complex{Float64}, 2}
   A_mul_B!(v.vqh,  g.rfftplan, v.vq)
 
   # Nonlinear term for q
-  NL .= (-im) .* g.Kr.*v.uUqh .- im .* g.Lr.*v.vqh - p.beta.*v.vh
+  N .= (-im) .* g.Kr.*v.uUqh .- im .* g.Lr.*v.vqh - p.beta.*v.vh
 
   # 'Nonlinear' term for U with topo correlation.
   # Note: < v*eta > = sum( conj(vh)*eta* ) / (nx^2*ny^2)
-  NL[1, 1] = p.FU(t) - sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
+  N[1, 1] = p.FU(t) - sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
 
 end
 
 
-function calc_const_mean_NL!(NL::Array{Complex{Float64}, 2},
+function calc_const_mean_N!(N::Array{Complex{Float64}, 2},
   sol::Array{Complex{Float64}, 2}, t::Float64, v::Vars,
   p::ConstMeanParams, g::TwoDGrid)
   # Calculate the nonlinear part of a 2D equation
@@ -291,13 +291,13 @@ function calc_const_mean_NL!(NL::Array{Complex{Float64}, 2},
   A_mul_B!(v.vqh,  g.rfftplan, v.vq)
 
   # Nonlinear term for q
-  NL .= (-im) .* g.Kr.*v.uUqh .- im .* g.Lr.*v.vqh .- p.beta.*v.vh
+  N .= (-im) .* g.Kr.*v.uUqh .- im .* g.Lr.*v.vqh .- p.beta.*v.vh
 
 end
 
 
 
-function calc_free_decay_NL!(NL::Array{Complex{Float64}, 2},
+function calc_free_decay_N!(N::Array{Complex{Float64}, 2},
   sol::Array{Complex{Float64}, 2}, t::Float64, v::FreeDecayVars,
   p::FreeDecayParams, g::TwoDGrid)
   # Calculate the nonlinear part of a 2D equation
@@ -322,7 +322,7 @@ function calc_free_decay_NL!(NL::Array{Complex{Float64}, 2},
   A_mul_B!(v.vqh, g.rfftplan, v.vq)
 
   # Nonlinear term for q
-  NL .= (-im) .* g.Kr.*v.uqh .- im .* g.Lr.*v.vqh .- p.beta.*v.vh
+  N .= (-im) .* g.Kr.*v.uqh .- im .* g.Lr.*v.vqh .- p.beta.*v.vh
 
 end
 

--- a/src/physics/barotropicqg.jl
+++ b/src/physics/barotropicqg.jl
@@ -84,11 +84,12 @@ end
 
 
 
-
 # E Q U A T I O N S -----------------------------------------------------------
 type Equation <: AbstractEquation
-  LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's linear part
-  calcN!::Function               # Function to calculate eqn's nonlinear part
+  LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's implicit 
+                                  # linear part
+  calcN!::Function                # Function to calculate the eqn's explicit  
+                                  # linear and nonlinear parts
 end
 
 function Equation(p::Params, g::TwoDGrid)
@@ -233,8 +234,8 @@ end
 
 function calcN!(N::Array{Complex{Float64}, 2}, sol::Array{Complex{Float64}, 2},
   t::Float64, v::Vars, p::Params, g::TwoDGrid)
-  # Calculate the nonlinear part of two equations: one 2D equation
-  # governing the evolution of a barotropic QG flow, and a single
+  # Calculate the explicit linear and nonlinear of two equations: one 2D 
+  # equation governing the evolution of a barotropic QG flow, and a single
   # 0-dimensional equation for the time evolution of the zonal mean.
 
   # Note: U is stored in sol[1, 1]; the other elements of sol are qh.
@@ -300,7 +301,7 @@ end
 function calc_free_decay_N!(N::Array{Complex{Float64}, 2},
   sol::Array{Complex{Float64}, 2}, t::Float64, v::FreeDecayVars,
   p::FreeDecayParams, g::TwoDGrid)
-  # Calculate the nonlinear part of a 2D equation
+  # Calculate the explicit linear and nonlinear part of a 2D equation
   # governing the unforced, free decay of a barotropic QG flow.
 
   # This copy is necessary because FFTW's irfft destroys its input.

--- a/src/physics/traceradvdiff.jl
+++ b/src/physics/traceradvdiff.jl
@@ -100,7 +100,7 @@ end
 # Equations
 type Equation <: AbstractEquation
   LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's linear part
-  calcNL!::Function               # Function to calculate eqn's nonlinear part
+  calcN!::Function               # Function to calculate eqn's nonlinear part
 end
 
 """ Initialize an equation with constant diffusivity problem parameters p
@@ -108,13 +108,13 @@ and on a grid g. """
 function Equation(p::ConstDiffParams, g::TwoDGrid)
   LC = zeros(g.Kr)
   @. LC = -p.η*g.kr^2 - p.κ*g.l^2
-  Equation(LC, calcNL!)
+  Equation(LC, calcN!)
 end
 
 function Equation(p::ConstDiffSteadyFlowParams, g::TwoDGrid)
   LC = zeros(g.Kr)
   @. LC = -p.η*g.kr^2 - p.κ*g.l^2 - p.κh*g.KKrsq^p.nκh
-  Equation(LC, calcNL_steadyflow!)
+  Equation(LC, calcN_steadyflow!)
 end
 
 
@@ -153,7 +153,7 @@ end
 Calculate the advective terms for a tracer equation with constant
 diffusivity.
 """
-function calcNL!(NL::Array{Complex{Float64},2},
+function calcN!(N::Array{Complex{Float64},2},
   sol::Array{Complex{Float64},2},
   t::Float64, v::Vars, p::ConstDiffParams, g::TwoDGrid)
 
@@ -169,7 +169,7 @@ function calcNL!(NL::Array{Complex{Float64},2},
   A_mul_B!(v.cuh, g.rfftplan, v.cu)
   A_mul_B!(v.cvh, g.rfftplan, v.cv)
 
-  @. NL = -im*g.kr*v.cuh - im*g.l*v.cvh
+  @. N = -im*g.kr*v.cuh - im*g.l*v.cvh
 
   nothing
 end
@@ -179,7 +179,7 @@ end
 Calculate the advective terms for a tracer equation with constant
 diffusivity and time-constant flow.
 """
-function calcNL_steadyflow!(NL::Array{Complex{Float64},2},
+function calcN_steadyflow!(N::Array{Complex{Float64},2},
   sol::Array{Complex{Float64},2},
   t::Float64, v::Vars, p::ConstDiffSteadyFlowParams, g::TwoDGrid)
 
@@ -192,7 +192,7 @@ function calcNL_steadyflow!(NL::Array{Complex{Float64},2},
   A_mul_B!(v.cuh, g.rfftplan, v.cu)
   A_mul_B!(v.cvh, g.rfftplan, v.cv)
 
-  @. NL = -im*g.kr*v.cuh - im*g.l*v.cvh
+  @. N = -im*g.kr*v.cuh - im*g.l*v.cvh
   nothing
 end
 

--- a/src/physics/traceradvdiff.jl
+++ b/src/physics/traceradvdiff.jl
@@ -99,8 +99,10 @@ end
 
 # Equations
 type Equation <: AbstractEquation
-  LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's linear part
-  calcN!::Function               # Function to calculate eqn's nonlinear part
+  LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's implicit
+                                  # linear part
+  calcN!::Function                # Function to calculate the eqn's explicit
+                                  # linear and nonlinear parts
 end
 
 """ Initialize an equation with constant diffusivity problem parameters p

--- a/src/physics/tracerpatcheqn.jl
+++ b/src/physics/tracerpatcheqn.jl
@@ -79,11 +79,11 @@ end
 # Equation --------------------------------------------------------------------
 type Equation <: AbstractEquation
   LC::Array{Float64, 1}
-  calcNL!::Function
+  calcN!::Function
 end
 
 function Equation()
-  Equation(zeros(5), calcNL!)
+  Equation(zeros(5), calcN!)
 end
 
 
@@ -99,7 +99,7 @@ end
 
 
 # Solver ----------------------------------------------------------------------
-function calcNL!(NL::Array{Float64, 1}, sol::Array{Float64, 1}, t::Float64,
+function calcN!(N::Array{Float64, 1}, sol::Array{Float64, 1}, t::Float64,
   v::Vars, p::AnalyticFlowParams, g::AbstractGrid)
 
   # Key:
@@ -118,21 +118,21 @@ function calcNL!(NL::Array{Float64, 1}, sol::Array{Float64, 1}, t::Float64,
 
   # ∂t ξ = u(ξ, ζ)
   # ∂t ζ = v(ξ, ζ)
-  NL[1] = p.u(sol[1], sol[2], t)
-  NL[2] = p.v(sol[1], sol[2], t)
+  N[1] = p.u(sol[1], sol[2], t)
+  N[2] = p.v(sol[1], sol[2], t)
 
   # ∂t m₁₁ = 2η + 2m₁₁dα + 2m₁₂dβ
-  NL[3] = (
+  N[3] = (
     2.0*p.η(sol[2])
     + 2.0*sol[3]*p.ux(sol[1], sol[2], t)
     + 2.0*sol[4]*p.uy(sol[1], sol[2], t)
   )
 
   # ∂t m₁₂ = m₂₂dβ + m₁₁dγ
-  NL[4] = sol[5]*p.uy(sol[1], sol[2], t) + sol[3]*p.vx(sol[1], sol[2], t)
+  N[4] = sol[5]*p.uy(sol[1], sol[2], t) + sol[3]*p.vx(sol[1], sol[2], t)
 
   # ∂t m₂₂ = 2κ - 2m₂₂dα + 2m₁₂dγ
-  NL[5] = (
+  N[5] = (
     2.0*p.κ(sol[1])
     - 2.0*sol[5]*p.ux(sol[1], sol[2], t)
     + 2.0*sol[4]*p.vx(sol[1], sol[2], t)

--- a/src/physics/twodturb.jl
+++ b/src/physics/twodturb.jl
@@ -63,13 +63,13 @@ end
 # Equations
 type Equation <: AbstractEquation
   LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's linear part
-  calcNL!::Function               # Function to calculate eqn's nonlinear part
+  calcN!::Function               # Function to calculate eqn's nonlinear part
 end
 
 function Equation(p::Params, g::TwoDGrid)
-  # Function calcNL! is defined below.
+  # Function calcN! is defined below.
   LC = -p.ν * g.KKrsq.^(0.5*p.nν)
-  Equation(LC, calcNL!)
+  Equation(LC, calcN!)
 end
 
 
@@ -124,7 +124,7 @@ end
 
 
 # Solvers
-function calcNL!(NL::Array{Complex{Float64}, 2}, sol::Array{Complex{Float64}, 2},
+function calcN!(N::Array{Complex{Float64}, 2}, sol::Array{Complex{Float64}, 2},
   t::Float64, v::Vars, p::Params, g::TwoDGrid)
   v.qh .= sol
   A_mul_B!(v.q, g.irfftplan, v.qh) # destroys qh when using fftw
@@ -141,7 +141,7 @@ function calcNL!(NL::Array{Complex{Float64}, 2}, sol::Array{Complex{Float64}, 2}
   A_mul_B!(v.Uqh, g.rfftplan, v.Uq)
   A_mul_B!(v.Vqh, g.rfftplan, v.Vq)
 
-  @. NL = -im*g.kr*v.Uqh - im*g.l*v.Vqh
+  @. N = -im*g.kr*v.Uqh - im*g.l*v.Vqh
   nothing
 end
 

--- a/src/physics/twodturb.jl
+++ b/src/physics/twodturb.jl
@@ -62,8 +62,10 @@ end
 
 # Equations
 type Equation <: AbstractEquation
-  LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's linear part
-  calcN!::Function               # Function to calculate eqn's nonlinear part
+  LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's implicit
+                                  # linear part
+  calcN!::Function                # Function to calculate the eqn's explicit
+                                  # linear and nonlinear parts
 end
 
 function Equation(p::Params, g::TwoDGrid)

--- a/src/physics/twomodeboussinesq.jl
+++ b/src/physics/twomodeboussinesq.jl
@@ -74,12 +74,12 @@ end
 type Equation <: AbstractEquation
   LCc::Array{Complex{Float64}, 3} # Element-wise coeff of the eqn's linear part
   LCr::Array{Complex{Float64}, 2} # Element-wise coeff of the eqn's linear part
-  calcNL!::Function               # Function to calculate eqn's nonlinear part
+  calcN!::Function               # Function to calculate eqn's nonlinear part
 end
 
 function Equation(p::TwoModeParams, g::TwoDGrid)
   LCc, LCr = getlinearcoefficients(p, g)
-  Equation(LCc, LCr, calcNL!)
+  Equation(LCc, LCr, calcN!)
 end
 
 function getlinearcoefficients(p::TwoModeParams, g::TwoDGrid)
@@ -237,8 +237,8 @@ end
 
 
 # Solvers ---------------------------------------------------------------------
-function calcNL!(
-  NLc::Array{Complex{Float64}, 3},  NLr::Array{Complex{Float64}, 2},
+function calcN!(
+  Nc::Array{Complex{Float64}, 3},  Nr::Array{Complex{Float64}, 2},
   solc::Array{Complex{Float64}, 3}, solr::Array{Complex{Float64}, 2},
   t::Float64, v::Vars, p::TwoModeParams, g::TwoDGrid)
 
@@ -309,23 +309,23 @@ function calcNL!(
   A_mul_B!(v.uVxvVyh, g.fftplan, v.uVxvVy)
 
   # Zeroth-mode nonlinear term
-  @. NLr = - im*g.kr*v.UZuzvwh - im*g.l*v.VZvzuwh
+  @. Nr = - im*g.kr*v.UZuzvwh - im*g.l*v.VZvzuwh
 
   # First-mode nonlinear terms:
   # u
-  @views @. NLc[:, :, 1] = (  p.f*solc[:, :, 2] - im*g.k*solc[:, :, 3]
+  @views @. Nc[:, :, 1] = (  p.f*solc[:, :, 2] - im*g.k*solc[:, :, 3]
     - im*g.k*v.Uuh - im*g.l*v.Vuh - v.uUxvUyh )
 
   # v
-  @views @. NLc[:, :, 2] = ( -p.f*solc[:, :, 1] - im*g.l*solc[:, :, 3]
+  @views @. Nc[:, :, 2] = ( -p.f*solc[:, :, 1] - im*g.l*solc[:, :, 3]
     - im*g.k*v.Uvh - im*g.l*v.Vvh - v.uVxvVyh )
 
   # p
-  @views @. NLc[:, :, 3] = ( im*p.N^2.0/p.m*v.wh
+  @views @. Nc[:, :, 3] = ( im*p.N^2.0/p.m*v.wh
     - im*g.k*v.Uph - im*g.l*v.Vph )
 
-  #dealias!(NLr, g)
-  #dealias!(NLc, g)
+  #dealias!(Nr, g)
+  #dealias!(Nc, g)
 
   nothing
 end

--- a/src/timesteppers.jl
+++ b/src/timesteppers.jl
@@ -234,7 +234,7 @@ mutable struct ETDRK4TimeStepper{dim} <: AbstractTimeStepper
   # Intermediate times, solutions, and nonlinear evaluations
   ti::Float64
   sol₁::Array{Complex{Float64}, dim}
-  sol2::Array{Complex{Float64}, dim}
+  sol₂::Array{Complex{Float64}, dim}
   N₁::Array{Complex{Float64}, dim}
   N₂::Array{Complex{Float64}, dim}
   N₃::Array{Complex{Float64}, dim}
@@ -250,14 +250,14 @@ function ETDRK4TimeStepper(dt::Float64, LC::AbstractArray)
   ti = 0.0
 
   sol₁ = zeros(LC)
-  sol2 = zeros(LC)
+  sol₂ = zeros(LC)
     N₁ = zeros(LC)
     N₂ = zeros(LC)
     N₃ = zeros(LC)
     N₄ = zeros(LC)
 
   ETDRK4TimeStepper{ndims(LC)}(0, dt, LC, ζ, α, β, Γ, expLCdt,
-    expLCdt2, ti, sol₁, sol2, N₁, N₂, N₃, N₄)
+    expLCdt2, ti, sol₁, sol₂, N₁, N₂, N₃, N₄)
 end
 
 
@@ -285,7 +285,7 @@ mutable struct FilteredETDRK4TimeStepper{dim} <: AbstractTimeStepper
   # Intermediate times, solutions, and nonlinear evaluations
   ti::Float64
   sol₁::Array{Complex{Float64}, dim}
-  sol2::Array{Complex{Float64}, dim}
+  sol₂::Array{Complex{Float64}, dim}
   N₁::Array{Complex{Float64}, dim}
   N₂::Array{Complex{Float64}, dim}
   N₃::Array{Complex{Float64}, dim}
@@ -304,7 +304,7 @@ function FilteredETDRK4TimeStepper(dt::Float64, LC::AbstractArray,
   ti = 0.0
 
   sol₁ = zeros(LC)
-  sol2 = zeros(LC)
+  sol₂ = zeros(LC)
     N₁ = zeros(LC)
     N₂ = zeros(LC)
     N₃ = zeros(LC)
@@ -323,7 +323,7 @@ function FilteredETDRK4TimeStepper(dt::Float64, LC::AbstractArray,
   filter = ones(real.(LC)) .* filter
 
   FilteredETDRK4TimeStepper{ndims(LC)}(0, dt, LC, ζ, α, β, Γ,
-        expLCdt, expLCdt2, ti, sol₁, sol2, N₁, N₂, N₃, N₄, filter)
+        expLCdt, expLCdt2, ti, sol₁, sol₂, N₁, N₂, N₃, N₄, filter)
 end
 
 
@@ -360,15 +360,15 @@ function stepforward!(v::AbstractVars, ts::ETDRK4TimeStepper,
   # Substep 2
   ts.ti = v.t + 0.5*ts.dt
   eq.calcN!(ts.N₂, ts.sol₁, ts.ti, v, p, g)
-  @. ts.sol2 = ts.expLCdt2*v.sol + ts.ζ*ts.N₂
+  @. ts.sol₂ = ts.expLCdt2*v.sol + ts.ζ*ts.N₂
 
   # Substep 3
-  eq.calcN!(ts.N₃, ts.sol2, ts.ti, v, p, g)
-  @. ts.sol2 = ts.expLCdt2*ts.sol₁ + ts.ζ*(2.0*ts.N₃ - ts.N₁)
+  eq.calcN!(ts.N₃, ts.sol₂, ts.ti, v, p, g)
+  @. ts.sol₂ = ts.expLCdt2*ts.sol₁ + ts.ζ*(2.0*ts.N₃ - ts.N₁)
 
   # Substep 4
   ts.ti = v.t + ts.dt
-  eq.calcN!(ts.N₄, ts.sol2, ts.ti, v, p, g)
+  eq.calcN!(ts.N₄, ts.sol₂, ts.ti, v, p, g)
 
   # Update
   @. v.sol = (ts.expLCdt.*v.sol +     ts.α * ts.N₁
@@ -394,15 +394,15 @@ function stepforward!(v::AbstractVars, ts::FilteredETDRK4TimeStepper,
   # Substep 2
   ts.ti = v.t + 0.5*ts.dt
   eq.calcN!(ts.N₂, ts.sol₁, ts.ti, v, p, g)
-  @. ts.sol2 = ts.expLCdt2*v.sol + ts.ζ*ts.N₂
+  @. ts.sol₂ = ts.expLCdt2*v.sol + ts.ζ*ts.N₂
 
   # Substep 3
-  eq.calcN!(ts.N₃, ts.sol2, ts.ti, v, p, g)
-  @. ts.sol2 = ts.expLCdt2*ts.sol₁ + ts.ζ*(2.0*ts.N₃ - ts.N₁)
+  eq.calcN!(ts.N₃, ts.sol₂, ts.ti, v, p, g)
+  @. ts.sol₂ = ts.expLCdt2*ts.sol₁ + ts.ζ*(2.0*ts.N₃ - ts.N₁)
 
   # Substep 4
   ts.ti = v.t + ts.dt
-  eq.calcN!(ts.N₄, ts.sol2, ts.ti, v, p, g)
+  eq.calcN!(ts.N₄, ts.sol₂, ts.ti, v, p, g)
 
   # Update
   @. v.sol = ts.filter*(ts.expLCdt*v.sol +     ts.α * ts.N₁
@@ -429,19 +429,19 @@ function stepforward!(v::AbstractVars, ts::DualETDRK4TimeStepper,
   # Substep 2
   ts.c.ti = v.t + 0.5*ts.c.dt
   eq.calcN!(ts.c.N₂, ts.r.N₂, ts.c.sol₁, ts.r.sol₁, ts.c.ti, v, p, g)
-  @. ts.c.sol2 = ts.c.expLCdt2*v.solc + ts.c.ζ*ts.c.N₂
-  @. ts.r.sol2 = ts.r.expLCdt2*v.solr + ts.r.ζ*ts.r.N₂
+  @. ts.c.sol₂ = ts.c.expLCdt2*v.solc + ts.c.ζ*ts.c.N₂
+  @. ts.r.sol₂ = ts.r.expLCdt2*v.solr + ts.r.ζ*ts.r.N₂
 
   # Substep 3
-  eq.calcN!(ts.c.N₃, ts.r.N₃, ts.c.sol2, ts.r.sol2, ts.c.ti, v, p, g)
-  @. ts.c.sol2 = (ts.c.expLCdt2*ts.c.sol₁
+  eq.calcN!(ts.c.N₃, ts.r.N₃, ts.c.sol₂, ts.r.sol₂, ts.c.ti, v, p, g)
+  @. ts.c.sol₂ = (ts.c.expLCdt2*ts.c.sol₁
     + ts.c.ζ*(2.0*ts.c.N₃ - ts.c.N₁))
-  @. ts.r.sol2 = (ts.r.expLCdt2*ts.r.sol₁
+  @. ts.r.sol₂ = (ts.r.expLCdt2*ts.r.sol₁
     + ts.r.ζ*(2.0*ts.r.N₃ - ts.r.N₁))
 
   # Substep 4
   ts.c.ti = v.t + ts.c.dt
-  eq.calcN!(ts.c.N₄, ts.r.N₄, ts.c.sol2, ts.r.sol2, ts.c.ti, v, p, g)
+  eq.calcN!(ts.c.N₄, ts.r.N₄, ts.c.sol₂, ts.r.sol₂, ts.c.ti, v, p, g)
 
   # Update
   @. v.solc = (ts.c.expLCdt.*v.solc +     ts.c.α * ts.c.N₁

--- a/src/timesteppers.jl
+++ b/src/timesteppers.jl
@@ -123,7 +123,7 @@ end
 mutable struct ForwardEulerTimeStepper{dim} <: AbstractTimeStepper
   step::Int
   dt::Float64
-  N::Array{Complex{Float64},dim}    # Nonlinear term
+  N::Array{Complex{Float64},dim}    # Explicit linear and nonlinear terms
 end
 
 function ForwardEulerTimeStepper(dt::Float64, v::AbstractVars)
@@ -164,7 +164,7 @@ end
 mutable struct FilteredForwardEulerTimeStepper{dim} <: AbstractTimeStepper
   step::Int
   dt::Float64
-  N::Array{Complex{Float64},dim}   # Nonlinear term
+  N::Array{Complex{Float64},dim}    # Explicit linear and nonlinear terms
   filter::Array{Float64,dim}        # Filter for solution
 end
 
@@ -213,7 +213,7 @@ end
 
 
 # ETDRK4 ----------------------------------------------------------------------
-# The Rolls-Royce of time-stepping. Exact treatment of linear part of
+# The Rolls-Royce of time-stepping. Exact treatment of the implicit linear part of
 # the equation, explicit and 4th-order accurate integration of nonlinear
 # parts of equation.
 


### PR DESCRIPTION
This PR changes a core semantics of the code. We decided it's better to rename the function `calcNL!` to `calcN!`. This is potentially less confusing, because `calcN` may include linear terms. In addition, this is more consistent with most mathematical notation for PDEs, which refer to a function N(u) [and not NL(u)], for example.

It also changes the names of fields of timestepper Composite Types to be consistent with this change, so that, for example, the array `ForwardEuler.NL` is now called `ForwardEuler.N`.