### PR TITLE
@createarrays macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: julia
 
 os:
-  - osx
+ # - osx
   - linux
 
 julia:
   # - nightly
-  - 0.6.0
+  # - 0.6.0
   - 0.6.2
 
 before_script:

--- a/src/physics/twodturb.jl
+++ b/src/physics/twodturb.jl
@@ -103,7 +103,8 @@ function Vars(g::TwoDGrid)
   sol  = zeros(Complex128, g.nkr, g.nl)
 
   # Vorticity auxiliary vars
-  FourierFlows.@createarrays Float64 (g.nx, g.ny) q U V Uq Vq psi
+  @createarrays Float64 (g.nx, g.ny) q U V Uq Vq psi
+  @createarrays Complex{Float64} (g.nkr, g.nl) qh Uh Vh Uqh Vqh psih
   #q    = zeros(Float64, g.nx, g.ny)
   #U    = zeros(Float64, g.nx, g.ny)
   #V    = zeros(Float64, g.nx, g.ny)
@@ -111,12 +112,12 @@ function Vars(g::TwoDGrid)
   #Vq   = zeros(Float64, g.nx, g.ny)
   #psi  = zeros(Float64, g.nx, g.ny)
 
-  qh   = zeros(Complex128, g.nkr, g.nl)
-  Uh   = zeros(Complex128, g.nkr, g.nl)
-  Vh   = zeros(Complex128, g.nkr, g.nl)
-  Uqh  = zeros(Complex128, g.nkr, g.nl)
-  Vqh  = zeros(Complex128, g.nkr, g.nl)
-  psih = zeros(Complex128, g.nkr, g.nl)
+  #qh   = zeros(Complex128, g.nkr, g.nl)
+  #Uh   = zeros(Complex128, g.nkr, g.nl)
+  #Vh   = zeros(Complex128, g.nkr, g.nl)
+  #Uqh  = zeros(Complex128, g.nkr, g.nl)
+  #Vqh  = zeros(Complex128, g.nkr, g.nl)
+  #psih = zeros(Complex128, g.nkr, g.nl)
 
   sol = exp.( 2π*im*rand(g.nkr, g.nl) ) # Random initial condition
 

--- a/src/physics/twodturb.jl
+++ b/src/physics/twodturb.jl
@@ -54,28 +54,26 @@ function InitialValueProblem(nx, Lx, ny, Ly, ν, nν, dt, withfilter)
 end
 
 # Params
-type Params <: AbstractParams
+struct Params <: AbstractParams
   ν::Float64                     # Vorticity viscosity
   nν::Int                        # Vorticity hyperviscous order
 end
 
 
 # Equations
-type Equation <: AbstractEquation
+struct Equation <: AbstractEquation
   LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's linear part
   calcN!::Function               # Function to calculate eqn's nonlinear part
 end
 
 function Equation(p::Params, g::TwoDGrid)
-  # Function calcN! is defined below.
   LC = -p.ν * g.KKrsq.^(0.5*p.nν)
   Equation(LC, calcN!)
 end
 
 
 # Vars
-type Vars <: AbstractVars
-
+mutable struct Vars <: AbstractVars
   t::Float64
   sol::Array{Complex128, 2}
 
@@ -94,34 +92,12 @@ type Vars <: AbstractVars
   Uqh::Array{Complex128,2}
   Vqh::Array{Complex128,2}
   psih::Array{Complex128,2}
-
 end
 
 function Vars(g::TwoDGrid)
-  # Initialize with t=0
-  t = 0.0
-  sol  = zeros(Complex128, g.nkr, g.nl)
-
-  # Vorticity auxiliary vars
   @createarrays Float64 (g.nx, g.ny) q U V Uq Vq psi
-  @createarrays Complex{Float64} (g.nkr, g.nl) qh Uh Vh Uqh Vqh psih
-  #q    = zeros(Float64, g.nx, g.ny)
-  #U    = zeros(Float64, g.nx, g.ny)
-  #V    = zeros(Float64, g.nx, g.ny)
-  #Uq   = zeros(Float64, g.nx, g.ny)
-  #Vq   = zeros(Float64, g.nx, g.ny)
-  #psi  = zeros(Float64, g.nx, g.ny)
-
-  #qh   = zeros(Complex128, g.nkr, g.nl)
-  #Uh   = zeros(Complex128, g.nkr, g.nl)
-  #Vh   = zeros(Complex128, g.nkr, g.nl)
-  #Uqh  = zeros(Complex128, g.nkr, g.nl)
-  #Vqh  = zeros(Complex128, g.nkr, g.nl)
-  #psih = zeros(Complex128, g.nkr, g.nl)
-
-  sol = exp.( 2π*im*rand(g.nkr, g.nl) ) # Random initial condition
-
-  Vars(t, sol, q, U, V, Uq, Vq, psi, qh, Uh, Vh, Uqh, Vqh, psih)
+  @createarrays Complex{Float64} (g.nkr, g.nl) sol qh Uh Vh Uqh Vqh psih
+  Vars(0.0, sol, q, U, V, Uq, Vq, psi, qh, Uh, Vh, Uqh, Vqh, psih)
 end
 
 

--- a/src/physics/twodturb.jl
+++ b/src/physics/twodturb.jl
@@ -103,12 +103,13 @@ function Vars(g::TwoDGrid)
   sol  = zeros(Complex128, g.nkr, g.nl)
 
   # Vorticity auxiliary vars
-  q    = zeros(Float64, g.nx, g.ny)
-  U    = zeros(Float64, g.nx, g.ny)
-  V    = zeros(Float64, g.nx, g.ny)
-  Uq   = zeros(Float64, g.nx, g.ny)
-  Vq   = zeros(Float64, g.nx, g.ny)
-  psi  = zeros(Float64, g.nx, g.ny)
+  FourierFlows.@createarrays Float64 (g.nx, g.ny) q U V Uq Vq psi
+  #q    = zeros(Float64, g.nx, g.ny)
+  #U    = zeros(Float64, g.nx, g.ny)
+  #V    = zeros(Float64, g.nx, g.ny)
+  #Uq   = zeros(Float64, g.nx, g.ny)
+  #Vq   = zeros(Float64, g.nx, g.ny)
+  #psi  = zeros(Float64, g.nx, g.ny)
 
   qh   = zeros(Complex128, g.nkr, g.nl)
   Uh   = zeros(Complex128, g.nkr, g.nl)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,9 +5,9 @@ import SpecialFunctions
     @createarrays T dims a b c 
 
 Create arrays of all zeros with element type T, size dims, and global names
-a, b, c...
+a, b, c (for example). An arbitrary number of arrays may be created.
 """
-macro createarrays(T::DataType, dims::Tuple, vars...)
+macro createarrays(T, dims, vars...)
   expr = Expr(:block)
   append!(expr.args, 
     [:( $(esc(var)) = zeros($(esc(T)), $(esc(dims))); ) for var in vars])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,7 @@
 import SpecialFunctions
 
+export @createarrays
+
 
 """
     @createarrays T dims a b c 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,22 @@
 import SpecialFunctions
 
 
+"""
+    @createarrays T dims a b c 
+
+Create arrays of all zeros with element type T, size dims, and global names
+a, b, c...
+"""
+macro createarrays(T::DataType, dims::Tuple, vars...)
+  expr = Expr(:block)
+  append!(expr.args, 
+    [:( $(esc(var)) = zeros($(esc(T)), $(esc(dims))); ) for var in vars])
+  expr
+end
+
+
+
+
 "Return the fftwavenumber vector with length n and domain size L."
 fftwavenums(n::Int; L=1.0) = 2.0*pi/L*cat(1, 0:n/2, -n/2+1:-1)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,10 @@
 #!/usr/bin/env julia
 
-#Start Test Script
+# Start Test Script
 using FourierFlows
 using Base.Test
 
 # Run tests
-
 tic()
 println("Starting Tests")
 println(" ")

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -36,10 +36,19 @@ function testparsevalsum2(func, grid; realvalued=true)
     isapprox(integral, parsevalsum2; atol=1.0e-14)
 end
 
-function testjacobian(a, b, analytic_answer, grid)
 
-    # compute the J(a,b) and compare witt analytic_answer
-    isapprox(norm(FourierFlows.jacobian(a, b, grid)), norm(analytic_answer); atol=g.nx*g.ny*1e-14)
+"""
+Compute the J(a,b) and compare with analytic_answer.
+"""
+function testjacobian(a, b, analytic_answer, grid)
+    isapprox(norm(FourierFlows.jacobian(a, b, grid)), norm(analytic_answer); 
+             atol=g.nx*g.ny*1e-14)
+end
+
+function testcreatearrays(T=Float64, dims=(13, 45))
+  a1, b1 = zeros(T, dims), zeros(T, dims)
+  FourierFlows.@createarrays T dims a2 b2
+  a1 == a2 && b1 == b2
 end
 
 
@@ -80,3 +89,5 @@ Js1s2 = (k1*l2-k2*l1)*cos.(k1*x + l1*y).*cos.(k2*x + l2*y)
 
 @test testjacobian(s1, s1, 0*s1, g) # test that J(a,a)=0
 @test testjacobian(s1, s2, Js1s2, g) # test J(s1,s2)=Js1s2
+
+@test testcreatearrays() # Test that @createarrays works properly.


### PR DESCRIPTION
This PR defines a macro that makes initializing many arrays of zeros much easier. The syntax

```
@createarrays T dims a b c
```

will create three arrays of zeros named `a`, `b`, and `c` with type `T` and size `dims`. This is basically equivalent to

```
a = zeros(T, dims)
b = zeros(T, dims)
c = zeros(T, dims)
```

Hopefully this saves a lot of boilerplate.