### PR TITLE
Equation type refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: julia
 
 os:
-  - osx
+ # - osx
   - linux
 
 julia:
   # - nightly
-  - 0.6.0
+  # - 0.6.0
   - 0.6.2
 
 before_script:

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -23,6 +23,24 @@ abstract type AbstractTimeStepper end
 abstract type AbstractProblem end
 
 
+"""
+This type defines the linear implicit and explicit components of an equation.
+The linear implicit part of an equation is defined by an array of coefficients
+which multiply the solution. The explicit part of an equation is calculated
+by a function that may define linear and nonlinear parts.
+"""
+struct Equation{dims} <: AbstractEquation
+  LC::Array{Complex{Float64},dims} # Coeffs of the eqn's implicit linear part
+  calcN!::Function # Function that calcs linear & nonlinear parts
+end
+
+struct DualEquation{dimsc,dimsr} <: AbstractEquation
+  LCc::Array{Complex{Float64},dimsc}
+  LCr::Array{Complex{Float64},dimsr}
+  calcN!::Function
+end
+
+
 
 
 # Problem type and associated functions

--- a/src/physics/barotropicqg.jl
+++ b/src/physics/barotropicqg.jl
@@ -85,28 +85,21 @@ end
 
 
 # E Q U A T I O N S -----------------------------------------------------------
-type Equation <: AbstractEquation
-  LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's implicit 
-                                  # linear part
-  calcN!::Function                # Function to calculate the eqn's explicit  
-                                  # linear and nonlinear parts
-end
-
 function Equation(p::Params, g::TwoDGrid)
   LC = -p.mu - p.nu.*g.KKrsq.^(0.5*p.nun)
-  Equation(LC, calcN!)
+  FourierFlows.Equation{2}(LC, calcN!)
 end
 
 function Equation(p::ConstMeanParams, g::TwoDGrid)
   # Function calcN! is defined below.
   LC = -p.mu - p.nu.*g.KKrsq.^(0.5*p.nun)
-  Equation(LC, calc_const_mean_N!)
+  FourierFlows.Equation{2}(LC, calc_const_mean_N!)
 end
 
 function Equation(p::FreeDecayParams, g::TwoDGrid)
   # Function calcN! is defined below.
   LC = -p.mu - p.nu.*g.KKrsq.^(0.5*p.nun)
-  Equation(LC, calc_free_decay_N!)
+  FourierFlows.Equation{2}(LC, calc_free_decay_N!)
 end
 
 

--- a/src/physics/traceradvdiff.jl
+++ b/src/physics/traceradvdiff.jl
@@ -95,28 +95,18 @@ end
 
 
 
-
-
-# Equations
-type Equation <: AbstractEquation
-  LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's implicit
-                                  # linear part
-  calcN!::Function                # Function to calculate the eqn's explicit
-                                  # linear and nonlinear parts
-end
-
 """ Initialize an equation with constant diffusivity problem parameters p
 and on a grid g. """
 function Equation(p::ConstDiffParams, g::TwoDGrid)
   LC = zeros(g.Kr)
   @. LC = -p.η*g.kr^2 - p.κ*g.l^2
-  Equation(LC, calcN!)
+  FourierFlows.Equation{2}(LC, calcN!)
 end
 
 function Equation(p::ConstDiffSteadyFlowParams, g::TwoDGrid)
   LC = zeros(g.Kr)
   @. LC = -p.η*g.kr^2 - p.κ*g.l^2 - p.κh*g.KKrsq^p.nκh
-  Equation(LC, calcN_steadyflow!)
+  FourierFlows.Equation{2}(LC, calcN_steadyflow!)
 end
 
 

--- a/src/physics/tracerpatcheqn.jl
+++ b/src/physics/tracerpatcheqn.jl
@@ -77,20 +77,15 @@ end
 
 
 # Equation --------------------------------------------------------------------
-type Equation <: AbstractEquation
-  LC::Array{Float64, 1}
-  calcN!::Function
-end
-
 function Equation()
-  Equation(zeros(5), calcN!)
+  FourierFlows.Equation{1}(zeros(5), calcN!)
 end
 
 
 # Vars ------------------------------------------------------------------------
 type Vars <: AbstractVars
   t::Float64
-  sol::Array{Float64, 1} # x, y, u, v, ux, uy, vx.
+  sol::Array{Float64,1} # x, y, u, v, ux, uy, vx.
 end
 
 function Vars()

--- a/src/physics/twodturb.jl
+++ b/src/physics/twodturb.jl
@@ -1,6 +1,6 @@
 module TwoDTurb
 
-using FourierFlows#, PyPlot
+using FourierFlows
 export InitialValueProblem, Params, Vars, Equation, set_q!, updatevars!
 
 # Problem ---------------------------------------------------------------------
@@ -8,15 +8,15 @@ export InitialValueProblem, Params, Vars, Equation, set_q!, updatevars!
 Construct an initial value problem.
 """
 function InitialValueProblem(;
-  nx  = 256,
-  Lx  = 2π,
-  ny  = nothing,
-  Ly  = nothing,
-  ν   = nothing,
-  nu  = nothing,
-  nν  = 2,
+   nx = 256,
+   Lx = 2π,
+   ny = nothing,
+   Ly = nothing,
+    ν = nothing,
+   nu = nothing,
+   nν = 2,
   nnu = nothing,
-  dt  = 0.01,
+   dt = 0.01,
   withfilter = false
   )
 
@@ -59,19 +59,10 @@ type Params <: AbstractParams
   nν::Int                        # Vorticity hyperviscous order
 end
 
-
 # Equations
-type Equation <: AbstractEquation
-  LC::Array{Complex{Float64}, 2}  # Element-wise coeff of the eqn's implicit
-                                  # linear part
-  calcN!::Function                # Function to calculate the eqn's explicit
-                                  # linear and nonlinear parts
-end
-
 function Equation(p::Params, g::TwoDGrid)
-  # Function calcN! is defined below.
   LC = -p.ν * g.KKrsq.^(0.5*p.nν)
-  Equation(LC, calcN!)
+  FourierFlows.Equation{2}(LC, calcN!)
 end
 
 

--- a/src/physics/twomodeboussinesq.jl
+++ b/src/physics/twomodeboussinesq.jl
@@ -71,15 +71,9 @@ end
 
 
 # Equations -------------------------------------------------------------------
-type Equation <: AbstractEquation
-  LCc::Array{Complex{Float64}, 3} # Element-wise coeff of the eqn's linear part
-  LCr::Array{Complex{Float64}, 2} # Element-wise coeff of the eqn's linear part
-  calcN!::Function               # Function to calculate eqn's nonlinear part
-end
-
 function Equation(p::TwoModeParams, g::TwoDGrid)
   LCc, LCr = getlinearcoefficients(p, g)
-  Equation(LCc, LCr, calcN!)
+  FourierFlows.DualEquation{3,2}(LCc, LCr, calcN!)
 end
 
 function getlinearcoefficients(p::TwoModeParams, g::TwoDGrid)


### PR DESCRIPTION
This PR moves the definition of the `Equation` Composite Type from each individual module to `FourierFlows.jl`. It also creates a new type `DualEquation` for problems that have mixed real and imaginary physical fields.

This change will reduce boiler plate, cuts down on the time to develop new modules, and ensures that new Equations are implemented in a regular way (i.e., the name of the `calcN!` function is assured for the time-stepper routines; etc).