### PR TITLE
Removes AB3 time stepper and adds new test_timesteppers.jl test

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Here's an overview of the code structure:
    - `timesteppers.jl`: defines modules and `stepforward!` routines for
         various time-steppers. Current implemented time-steppers are:
         - Forward Euler (+ Filtered Forward Euler)
-        - 3rd-order Adams-Bashforth (AB3)
         - 4th-order Runge-Kutta (RK4) (+ Filtered RK4)
         - 4th-order Runge-Kutta Exponential Time Differencing (ETDRK4)
         (+ Filtered ETDRK4)

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -128,14 +128,6 @@ function TwoDGrid(nx::Int, Lx::Float64, ny::Int=nx, Ly::Float64=Lx;
     fftplan, ifftplan, rfftplan, irfftplan, ialias, iralias, jalias)
 end
 
-# Grid constructor for tupled arguments
-function TwoDGrid(nxy::Tuple{Int, Int}, Lxy::Tuple{Float64, Float64};
-  nthreads=Sys.CPU_CORES)
-  nx, ny = nxy
-  Lx, Ly = Lxy
-  TwoDGrid(nx, Lx, ny, Ly; nthreads=nthreads)
-end
-
 function dealias!(a::Array{Complex{Float64},2}, g)
   if size(a)[1] == g.nkr
     a[g.iralias, g.jalias] = 0

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -9,7 +9,6 @@ export @createarrays
 steppers = [
   "ForwardEuler",
   "FilteredForwardEuler",
-  "AB3",
   "RK4",
   "FilteredRK4",
   "ETDRK4",

--- a/test/test_BarotropicQG_timesteppers.jl
+++ b/test/test_BarotropicQG_timesteppers.jl
@@ -66,7 +66,7 @@ eq = BarotropicQG.Equation(p, g)
 
 @test test_baroQG_timestep(g, p, v, eq, dt; stepper = "ForwardEuler")
 @test test_baroQG_timestep(g, p, v, eq, dt; stepper = "FilteredForwardEuler")
-@test test_baroQG_timestep(g, p, v, eq, dt; stepper = "AB3")
+# @test test_baroQG_timestep(g, p, v, eq, dt; stepper = "AB3")
 @test test_baroQG_timestep(g, p, v, eq, dt; stepper = "RK4")
 @test test_baroQG_timestep(g, p, v, eq, dt; stepper = "FilteredRK4")
 @test test_baroQG_timestep(g, p, v, eq, dt; stepper = "ETDRK4")

--- a/test/test_timesteppers.jl
+++ b/test/test_timesteppers.jl
@@ -1,5 +1,16 @@
 import FourierFlows.TwoDTurb
 
+# Dictionary of (stepper, nsteps) pairs to test. Each stepper is tested by
+# stepping forward nstep times.
+steppersteps = Dict([
+  ("ForwardEuler", 1000),
+  ("FilteredForwardEuler", 1000),
+  ("RK4", 100),
+  ("FilteredRK4", 100),
+  ("ETDRK4", 100),
+  ("FilteredETDRK4", 100),
+])
+
 
 """
 Build a twodturb initial value problem and use it to test time-stepping methods.
@@ -11,7 +22,7 @@ state qh(t) with qh(0)*exp(-ν k^2 t).
 function testtwodturbstepforward(n=64, L=2π, μ=0.1, nμ=0, ν=0.0, nν=2;
                                  nsteps=100, stepper="ForwardEuler")
 
-  dt = tf/steps
+  dt = tf/nsteps
 
   prob = TwoDTurb.InitialValueProblem(nx=n, Lx=L, ny=n, Ly=L, ν=ν, nν=nν, dt=dt,
                                         stepper=stepper)
@@ -42,16 +53,6 @@ end
 
 
 
-# Dictionary of (stepper, nsteps) pairs to test. Each stepper is tested by
-# stepping forward nstep times.
-steppersteps = Dict([
-  ("ForwardEuler", 1000),
-  ("FilteredForwardEuler", 1000),
-  ("RK4", 100),
-  ("FilteredRK4", 100),
-  ("ETDRK4", 100),
-  ("FilteredETDRK4", 100),
-])
 
 # Run the tests
 n = 64

--- a/test/test_timesteppers.jl
+++ b/test/test_timesteppers.jl
@@ -19,14 +19,14 @@ The amplitude of the initial condition is kept low (e.g. multiplied by 1e-5)
 so that nonlinear terms do not come into play. This way we can compare the final
 state qh(t) with qh(0)*exp(-ν k^2 t).
 """
-function testtwodturbstepforward(n=64, L=2π, μ=0.1, nμ=0, ν=0.0, nν=2;
+function testtwodturbstepforward(n=64, L=2π, ν=1e-3, nν=1;
                                  nsteps=100, stepper="ForwardEuler")
 
   dt = tf/nsteps
 
   prob = TwoDTurb.InitialValueProblem(nx=n, Lx=L, ny=n, Ly=L, ν=ν, nν=nν, dt=dt,
                                         stepper=stepper)
-  g = prob.grid
+  g, p, s = prob.grid, prob.params, prob.state
 
   # Initial condition (IC)
   qih = (rand(g.nkr, g.nl) + im*rand(g.nkr, g.nl))*1e-5
@@ -44,10 +44,9 @@ function testtwodturbstepforward(n=64, L=2π, μ=0.1, nμ=0, ν=0.0, nν=2;
   TwoDTurb.set_q!(prob, qi)
 
   stepforward!(prob, nsteps)
+  qfh = deepcopy(q0h).*exp.(-p.ν*g.KKrsq.^p.nν.*s.step*dt)
 
-  qfh = deepcopy(q0h).*exp.(-ν*g.KKrsq*prob.state.step*dt)
-
-  # println(sum(abs.(qfh-prob.state.sol)) / sum(abs.(qfh)))
+  # println(sum(abs.(qfh-s.sol)) / sum(abs.(qfh)))
   isapprox(qfh, prob.state.sol, rtol=n^2*nsteps*1e-13)
 end
 
@@ -56,7 +55,7 @@ end
 
 # Run the tests
 n = 64
-tf = 0.1
+tf = 0.2
 
 
 for (stepper, steps) in steppersteps

--- a/test/test_timesteppers.jl
+++ b/test/test_timesteppers.jl
@@ -1,4 +1,5 @@
 import FourierFlows.TwoDTurb
+import FourierFlows.TwoDTurb: energy
 
 # Dictionary of (stepper, nsteps) pairs to test. Each stepper is tested by
 # stepping forward nstep times.
@@ -17,16 +18,21 @@ Build a twodturb initial value problem and use it to test time-stepping methods.
 We integrate a random IC from 0 to t=tf.
 The amplitude of the initial condition is kept low (e.g. multiplied by 1e-5)
 so that nonlinear terms do not come into play. This way we can compare the final
-state qh(t) with qh(0)*exp(-ν k^2 t).
+state qh(t=tf) with qh(t=0)*exp(-ν k^nν tf).
+We choose to linear drag (nν=0) so that we can test the energy since in that
+case E(t=tf) = E(t=0)*exp(-2ν tf).
 """
-function testtwodturbstepforward(n=64, L=2π, ν=1e-3, nν=1;
+function testtwodturbstepforward(n=64, L=2π, ν=1e-2, nν=0;
                                  nsteps=100, stepper="ForwardEuler")
 
   dt = tf/nsteps
 
   prob = TwoDTurb.InitialValueProblem(nx=n, Lx=L, ny=n, Ly=L, ν=ν, nν=nν, dt=dt,
                                         stepper=stepper)
-  g, p, s = prob.grid, prob.params, prob.state
+  g, p, v, s = prob.grid, prob.params, prob.vars, prob.state
+
+  E = Diagnostic(energy, prob, nsteps=nsteps)
+  diags = [E]
 
   # Initial condition (IC)
   qih = (rand(g.nkr, g.nl) + im*rand(g.nkr, g.nl))*1e-5
@@ -42,12 +48,15 @@ function testtwodturbstepforward(n=64, L=2π, ν=1e-3, nν=1;
   q0h = deepcopy(qih)
 
   TwoDTurb.set_q!(prob, qi)
+  E0 = energy(s, v, g)
 
-  stepforward!(prob, nsteps)
+  stepforward!(prob, diags, nsteps)
+
   qfh = deepcopy(q0h).*exp.(-p.ν*g.KKrsq.^p.nν.*s.step*dt)
+   Ef = E0.*exp.(-2*p.ν*s.step*dt)
 
   # println(sum(abs.(qfh-s.sol)) / sum(abs.(qfh)))
-  isapprox(qfh, prob.state.sol, rtol=n^2*nsteps*1e-13)
+  isapprox(qfh, prob.state.sol, rtol=n^2*nsteps*1e-13) &  isapprox(Ef, E[E.count], rtol=n^2*nsteps*1e-13)
 end
 
 

--- a/test/test_timesteppers.jl
+++ b/test/test_timesteppers.jl
@@ -1,54 +1,62 @@
-using Base.Test, FourierFlows
 import FourierFlows.TwoDTurb
+
+
+"""
+Build a twodturb initial value problem and use it to test time-stepping methods.
+We integrate a random IC from 0 to t=tf.
+The amplitude of the initial condition is kept low (e.g. multiplied by 1e-5)
+so that nonlinear terms do not come into play. This way we can compare the final
+state qh(t) with qh(0)*exp(-ν k^2 t).
+"""
+function testtwodturbstepforward(n=64, L=2π, μ=0.1, nμ=0, ν=0.0, nν=2;
+                                 nsteps=100, stepper="ForwardEuler")
+
+  dt = tf/steps
+
+  prob = TwoDTurb.InitialValueProblem(nx=n, Lx=L, ny=n, Ly=L, ν=ν, nν=nν, dt=dt,
+                                        stepper=stepper)
+  g = prob.grid
+
+  # Initial condition (IC)
+  qih = (rand(g.nkr, g.nl) + im*rand(g.nkr, g.nl))*1e-5
+
+  # Remove high wavenumber power from IC
+  cutoff = 0.3
+  highwavenumbers = sqrt.( (g.Kr*g.dx/π).^2 + (g.Lr*g.dy/π).^2 ) .> cutoff
+  qih[highwavenumbers] =  0
+  qih[1,1] = 0
+  qi = irfft(qih, g.nx)
+  qih = rfft(qi)
+
+  q0h = deepcopy(qih)
+
+  TwoDTurb.set_q!(prob, qi)
+
+  stepforward!(prob, nsteps)
+
+  qfh = deepcopy(q0h).*exp.(-ν*g.KKrsq*prob.state.step*dt)
+
+  # println(sum(abs.(qfh-prob.state.sol)) / sum(abs.(qfh)))
+  isapprox(qfh, prob.state.sol, rtol=n^2*nsteps*1e-13)
+end
+
+
 
 # Dictionary of (stepper, nsteps) pairs to test. Each stepper is tested by
 # stepping forward nstep times.
 steppersteps = Dict([
-  ("ForwardEuler", 1),
-  ("FilteredForwardEuler", 1),
-  ("AB3", 3),
-  ("RK4", 1),
-  ("FilteredRK4", 1),
-  ("ETDRK4", 1),
-  ("FilteredETDRK4", 1),
+  ("ForwardEuler", 1000),
+  ("FilteredForwardEuler", 1000),
+  ("RK4", 100),
+  ("FilteredRK4", 100),
+  ("ETDRK4", 100),
+  ("FilteredETDRK4", 100),
 ])
-
-
-"""
-Build a twodturb problem, and use it to test time-stepping methods.
-"""
-function testtwodturbstepforward(n=64, L=2π, ν=0.0, nν=2;
-                                 dt=1e-16, nsteps=1, stepper="ForwardEuler")
-
-  g  = TwoDTurb.Grid(n, L)
-  p  = TwoDTurb.Params(ν, nν)
-  v  = TwoDTurb.Vars(g)
-  eq = TwoDTurb.Equation(p, g)
-  ts = FourierFlows.autoconstructtimestepper(stepper, dt, eq.LC, g)
-
-  # Initial condition (IC)
-  qi = rand(g.nx, g.ny)
-  qih = rfft(qi)
-
-  # Remove high wavenumber power from IC
-  cutoff = 0.3
-  highwavenumbers = (g.kr/g.k[2]).^2 .+ (g.l/g.l[2]).^2 .> cutoff # max is 0.5
-  qih[highwavenumbers] =  0
-  qi = irfft(qih, g.nx)
-
-  prob = Problem(g, v, p, eq, ts)
-  TwoDTurb.set_q!(prob, qi)
-
-  absq₀ = abs.(prob.state.sol)
-  stepforward!(prob, nsteps)
-  absq₁ = abs.(prob.state.sol)
-
-  isapprox(sum(absq₀-absq₁), 0.0, rtol=n^2*nsteps*1e-15)
-end
-
 
 # Run the tests
 n = 64
+tf = 0.1
+
 
 for (stepper, steps) in steppersteps
   @test testtwodturbstepforward(n; stepper=stepper, nsteps=steps)

--- a/test/test_timesteppers_dt.jl
+++ b/test/test_timesteppers_dt.jl
@@ -1,0 +1,54 @@
+using Base.Test, FourierFlows
+import FourierFlows.TwoDTurb
+
+# Dictionary of (stepper, nsteps) pairs to test. Each stepper is tested by
+# stepping forward nstep times.
+steppersteps = Dict([
+  ("ForwardEuler", 2),
+  ("FilteredForwardEuler", 2),
+  ("RK4", 2),
+  ("FilteredRK4", 2),
+  ("ETDRK4", 2),
+  ("FilteredETDRK4", 2),
+])
+
+
+"""
+Build a twodturb problem, and use it to test time-stepping methods.
+"""
+function testtwodturbstepforward(n=64, L=2π, ν=0.0, nν=2;
+                                 dt=1e-16, nsteps=1, stepper="ForwardEuler")
+
+  g  = TwoDTurb.Grid(n, L)
+  p  = TwoDTurb.Params(ν, nν)
+  v  = TwoDTurb.Vars(g)
+  eq = TwoDTurb.Equation(p, g)
+  ts = FourierFlows.autoconstructtimestepper(stepper, dt, eq.LC, g)
+
+  # Initial condition (IC)
+  qi = rand(g.nx, g.ny)
+  qih = rfft(qi)
+
+  # Remove high wavenumber power from IC
+  cutoff = 0.3
+  highwavenumbers = sqrt.( (g.Kr*g.dx/π).^2 + (g.Lr*g.dy/π).^2 ) .> cutoff
+  qih[highwavenumbers] =  0
+  qi = irfft(qih, g.nx)
+
+  prob = Problem(g, v, p, eq, ts)
+  TwoDTurb.set_q!(prob, qi)
+
+  absq₀ = abs.(prob.state.sol)
+  stepforward!(prob, nsteps)
+  absq₁ = abs.(prob.state.sol)
+  # println(sum(abs.(absq₀-absq₁)))
+  isapprox(sum(absq₀-absq₁), 0.0, atol=n^2*nsteps*1e-15)
+end
+
+
+# Run the tests
+n = 64
+
+for (stepper, steps) in steppersteps
+  @test testtwodturbstepforward(n; stepper=stepper, nsteps=steps)
+end


### PR DESCRIPTION
The new `test_timesteppers.jl` test is more robust and actually tests a bit of the physics.
It build a `twodturb` initial value problem and use it to test time-stepping methods. It integrates a random IC from `0` to `t=tf`. The amplitude of the initial condition is kept low (e.g. multiplied by `1e-5`) so that nonlinear terms do not come into play. This way the test compares the final
state `qh(t=tf)` with `qh(t=0)*exp(-ν k^{2*nν} t)`. When `nν=0` then we have plain linear drag. In that case the test can also compare the final energy `E(t=tf)` with `E(t=0)*exp(-2 ν t)`.
