### PR TITLE
generalizes the dealias! function in domains.jl

### DIFF
--- a/src/domains.jl
+++ b/src/domains.jl
@@ -130,9 +130,9 @@ end
 
 function dealias!(a::Array{Complex{Float64},dim}, g) where {dim}
   if size(a)[1] == g.nkr
-    @views @. a[g.iralias, g.jalias, :,:] = 0
+    @views @. a[g.iralias, g.jalias, :] = 0
   else
-    @views @. a[g.ialias, g.jalias, :,:] = 0
+    @views @. a[g.ialias, g.jalias, :] = 0
   end
   nothing
 end

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -128,23 +128,15 @@ function TwoDGrid(nx::Int, Lx::Float64, ny::Int=nx, Ly::Float64=Lx;
     fftplan, ifftplan, rfftplan, irfftplan, ialias, iralias, jalias)
 end
 
-function dealias!(a::Array{Complex{Float64},2}, g)
+function dealias!(a::Array{Complex{Float64},dim}, g) where {dim}
   if size(a)[1] == g.nkr
-    a[g.iralias, g.jalias] = 0
+    @views @. a[g.iralias, g.jalias, :,:] = 0
   else
-    a[g.ialias, g.jalias] = 0
+    @views @. a[g.ialias, g.jalias, :,:] = 0
   end
   nothing
 end
 
-function dealias!(a::Array{Complex{Float64},3}, g)
-  if size(a)[1] == g.nkr
-    @views @. a[g.iralias, g.jalias, :] = 0
-  else
-    @views @. a[g.ialias, g.jalias, :] = 0
-  end
-  nothing
-end
 
 """
 Returns an filter with an exponentially-decaying profile that, when multiplied


### PR DESCRIPTION
This PR replaces the two `dealias!` functions that were previously inside `domains.jl` with one that works for fields of any number of dimensions.