### PR TITLE
Forcing budgets (Stochastic & Deterministic forcing)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  # - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"

--- a/examples/twodturb/IsotropicRingForcing.jl
+++ b/examples/twodturb/IsotropicRingForcing.jl
@@ -1,0 +1,140 @@
+using PyPlot, FourierFlows
+import FourierFlows.TwoDTurb
+import FourierFlows.TwoDTurb: energy, enstrophy, dissipation, injection, drag
+
+ n, L  = 256, 2π
+ ν, nν = 1e-7, 2
+ μ, nμ = 1e-1, 0
+dt, tf = 0.005, 0.2/μ
+nt = round(Int, tf/dt)
+ns = 4
+
+# Forcing
+kf, dkf = 12.0, 2.0
+σ = 0.1
+
+gr  = TwoDGrid(n, L)
+
+force2k = exp.(-(sqrt.(gr.KKrsq)-kf).^2/(2*dkf^2))
+force2k[gr.KKrsq .< 2.0^2 ] = 0
+force2k[gr.KKrsq .> 20.0^2 ] = 0
+force2k[gr.Kr.<2π/L] = 0
+# σ0 = sum(force2k.*gr.invKKrsq/2.0)
+σ0 = FourierFlows.parsevalsum(force2k.*gr.invKKrsq/2.0, gr)/(gr.Lx*gr.Ly)
+force2k .= σ/σ0 * force2k
+
+srand(1234)
+
+function calcF!(F, sol, t, s, v, p, g)
+    eta = exp.(2π*im*rand(size(sol)))/sqrt(s.dt)
+    eta[1, 1] = 0
+    @. F = eta .* sqrt(force2k)
+    nothing
+end
+
+prob = TwoDTurb.ForcedProblem(nx=n, Lx=L, ν=ν, nν=nν, μ=μ, nμ=nμ, dt=dt,
+  stepper="RK4", calcF=calcF!)
+
+s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts;
+
+TwoDTurb.set_q!(prob, 0*g.X)
+E = Diagnostic(energy,      prob, nsteps=nt)
+D = Diagnostic(dissipation, prob, nsteps=nt)
+R = Diagnostic(drag,        prob, nsteps=nt)
+I = Diagnostic(injection,   prob, nsteps=nt)
+diags = [E, D, I, R]
+
+
+function makeplot(prob, diags)
+
+  TwoDTurb.updatevars!(prob)
+
+  E, D, I, R = diags
+
+
+  t = round(μ*prob.state.t, 2)
+  sca(axs[1]); cla()
+  pcolormesh(prob.grid.X, prob.grid.Y, prob.vars.q)
+  xlabel(L"$x$")
+  ylabel(L"$y$")
+  title("\$\\nabla^2\\psi(x,y,\\mu t= $t )\$")
+  axis("square")
+
+  sca(axs[3]); cla()
+
+  i₀ = 1
+  dEdt = (E[(i₀+1):E.count] - E[i₀:E.count-1])/prob.ts.dt
+  ii = (i₀):E.count-1
+  ii2 = (i₀+1):E.count
+
+  # dEdt = I - D - R?
+
+  # If the Ito interpretation was used for the work
+  # then we need to add the drift term
+  # total = I[ii2]+σ - D[ii] - R[ii]      # Ito
+  total = I[ii2] - D[ii] - R[ii]        # Stratonovich
+
+
+  residual = dEdt - total
+
+  # If the Ito interpretation was used for the work
+  # then we need to add the drift term: I[ii2] + σ
+  plot(μ*E.time[ii], I[ii2], label=L"work ($P$)")   # Ito
+  # plot(μ*E.time[ii], I[ii2] , label=L"work ($P$)")      # Stratonovich
+  plot(μ*E.time[ii], σ+0*E.time[ii], "--", label=L"ensemble mean  work ($\langle P\rangle $)")
+  # plot(μ*E.time[ii], -D[ii], label="dissipation (\$D\$)")
+  plot(μ*E.time[ii], -R[ii], label=L"drag ($D=2\mu E$)")
+  plot(μ*E.time[ii], 0*E.time[ii], "k:", linewidth=0.5)
+  ylabel("Energy sources and sinks")
+  xlabel(L"$\mu t$")
+  legend(fontsize=10)
+
+  sca(axs[2]); cla()
+  plot(μ*E.time[ii], total[ii], label=L"computed $P-D$")
+  plot(μ*E.time[ii], dEdt, "--k", label=L"numerical $dE/dt$")
+  ylabel(L"$dE/dt$")
+  xlabel(L"$\mu t$")
+  legend(fontsize=10)
+
+  sca(axs[4]); cla()
+  plot(μ*E.time[ii], residual, "c-", label=L"residual $dE/dt$ = computed $-$ numerical")
+  xlabel(L"$\mu t$")
+  legend(fontsize=10)
+
+  residual
+end
+
+fig, axs = subplots(ncols=2, nrows=2, figsize=(12, 8))
+
+# Step forward
+for i = 1:ns
+  tic()
+
+  stepforward!(prob, diags, round(Int, nt/ns))
+  tc = toq()
+
+  TwoDTurb.updatevars!(prob)
+  # saveoutput(out)
+
+  cfl = prob.ts.dt*maximum(
+    [maximum(v.V)/g.dx, maximum(v.U)/g.dy])
+
+  res = makeplot(prob, diags)
+  pause(0.01)
+
+  # @printf("step: %04d, t: %.1f, cfl: %.3f, time: %.2f s, mean(res) = %.3e\n",
+  #   prob.step, prob.t, cfl, tc, mean(res))
+  @printf("step: %04d, t: %.1f, cfl: %.3f, time: %.2f s\n",
+    prob.step, prob.t, cfl, tc)
+
+  # savename = @sprintf("./plots/stochastictest_kf%d_%06d.png", kf, prob.step)
+  # savefig(savename, dpi=240)
+end
+
+# savename = @sprintf("./plots/stochastictest_kf%d_%06d.png", kf, prob.step)
+# savefig(savename, dpi=240)
+
+# savediagnostic(E, "energy", out.filename)
+# savediagnostic(D, "dissipation", out.filename)
+# savediagnostic(I, "injection", out.filename)
+# savediagnostic(R, "drag", out.filename)

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -10,7 +10,7 @@ mutable struct Diagnostic{T} <: AbstractDiagnostic
   prob::Problem
   num::Int
   data::Array{T, 1}
-  time::Array{Float64, 1}
+  time::Array{Float, 1}
   step::Array{Int, 1}
   value::T
   count::Int
@@ -25,7 +25,7 @@ function Diagnostic(calc::Function, prob::FourierFlows.Problem; freq=1,
   T = typeof(value)
 
   data = Array{T}(num)
-  time = Array{Float64}(num)
+  time = Array{Float}(num)
   step = Array{Int}(num)
 
   data[1] = value

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -11,7 +11,7 @@ mutable struct Diagnostic{T} <: AbstractDiagnostic
   num::Int
   data::Array{T, 1}
   time::Array{Float64, 1}
-  step::Array{Int64, 1}
+  step::Array{Int, 1}
   value::T
   count::Int
   freq::Int
@@ -26,7 +26,7 @@ function Diagnostic(calc::Function, prob::FourierFlows.Problem; freq=1,
 
   data = Array{T}(num)
   time = Array{Float64}(num)
-  step = Array{Int64}(num)
+  step = Array{Int}(num)
 
   data[1] = value
   time[1] = prob.t
@@ -39,10 +39,10 @@ function getindex(d::Diagnostic, inds...)
   getindex(d.data, inds...)
 end
 
-""" 
+"""
     resize!(diag, newnum)
 
-Resize the Diagnostic data and time arrays to length newnum. 
+Resize the Diagnostic data and time arrays to length newnum.
 """
 function resize!(diag::AbstractDiagnostic, newnum::Int)
   resize!(diag.data, newnum)
@@ -51,7 +51,7 @@ function resize!(diag::AbstractDiagnostic, newnum::Int)
   nothing
 end
 
-""" 
+"""
     update!(diag)
 
 Update diag with its current value.
@@ -71,7 +71,7 @@ function update!(diags::AbstractArray)
   nothing
 end
 
-""" 
+"""
     increment!(diag)
 
 Increment the Diagnostic diag.
@@ -92,10 +92,10 @@ function increment!(diag::AbstractDiagnostic)
   nothing
 end
 
-""" 
+"""
     increment!(diags)
 
-Increment the array of Diagnostics diags. 
+Increment the array of Diagnostics diags.
 """
 function increment!(diags::AbstractArray)
   for d in diags

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -10,7 +10,7 @@ mutable struct Diagnostic{T} <: AbstractDiagnostic
   prob::Problem
   num::Int
   data::Array{T, 1}
-  time::Array{Float, 1}
+  time::Array{Float64, 1}
   step::Array{Int, 1}
   value::T
   count::Int
@@ -25,7 +25,7 @@ function Diagnostic(calc::Function, prob::FourierFlows.Problem; freq=1,
   T = typeof(value)
 
   data = Array{T}(num)
-  time = Array{Float}(num)
+  time = Array{Float64}(num)
   step = Array{Int}(num)
 
   data[1] = value

--- a/src/physics/twodturb.jl
+++ b/src/physics/twodturb.jl
@@ -164,11 +164,9 @@ end
 function calcN_forced!(N::Array{Complex{Float64}, 2},
                 sol::Array{Complex{Float64}, 2}, t::Float64,
                 s::State, v::ForcedVars, p::ForcedParams, g::TwoDGrid)
-  if t == s.t
-    v.prevsol .= s.sol    # this is used for computing energy/enstrophy budgets
-  end
   calcN_advection!(N, sol, t, s, v, p, g)
   if t == s.t # not a substep
+    v.prevsol .= s.sol    # this is used for computing energy/enstrophy budgets
     p.calcF!(v.Fh, sol, t, s, v, p, g)
   end
   @. N += v.Fh
@@ -269,18 +267,18 @@ end
 end
 
 """
-    injection(s, v, p, g)
+    work(s, v, p, g)
 
-Returns the domain-averaged rate of injection of energy by the forcing Fh.
+Returns the domain-averaged rate of work of energy by the forcing Fh.
 """
-@inline function injection(s, v::ForcedVars, g)
+@inline function work(s, v::ForcedVars, g)
   @. v.Uh = g.invKKrsq * (v.prevsol + s.sol)/2.0 * conj(v.Fh) # Stratonovich
   # @. v.Uh = g.invKKrsq * v.prevsol * conj(v.Fh)               # Ito
   1/(g.Lx*g.Ly)*FourierFlows.parsevalsum(v.Uh, g)
 end
 
-@inline function injection(prob::AbstractProblem)
-  injection(prob.state, prob.vars, prob.grid)
+@inline function work(prob::AbstractProblem)
+  work(prob.state, prob.vars, prob.grid)
 end
 
 """

--- a/test/test_barotropicqg.jl
+++ b/test/test_barotropicqg.jl
@@ -56,6 +56,9 @@ dt, nsteps  = 1e-3, 200
 @test test_baroQG_RossbyWave("ETDRK4", dt, nsteps, g, p, v, eq)
 
 dt, nsteps  = 1e-3, 200
+@test test_baroQG_RossbyWave("FilteredETDRK4", dt, nsteps, g, p, v, eq)
+
+dt, nsteps  = 1e-3, 200
 @test test_baroQG_RossbyWave("RK4", dt, nsteps, g, p, v, eq)
 
 dt, nsteps  =1e-3, 200

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -46,13 +46,13 @@ end
 
 
 # ISOTROPIC RING FORCING BUDGETS
-function stochasticforcingbudgetstest( n ; dt = 0.01, L=2π, ν=1e-7, nν=2,
-                                            μ = 1e-1, nμ = 0, message=false)
+function stochasticforcingbudgetstest( ; n = 256, dt = 0.01, L=2π, ν=1e-7, nν=2,
+                                         μ = 1e-1, nμ = 0, message=false)
 
   n, L  = 256, 2π
   ν, nν = 1e-7, 2
   μ, nμ = 1e-1, 0
-  dt, tf = 0.005, 0.2/μ
+  dt, tf = 0.005, 0.1/μ
   nt = round(Int, tf/dt)
   ns = 1
 
@@ -123,7 +123,7 @@ function stochasticforcingbudgetstest( n ; dt = 0.01, L=2π, ν=1e-7, nν=2,
             prob.step, prob.t, cfl, tc)
   end
 
-  # println(mean(abs.(residual)))
+  println(mean(abs.(residual)))
   isapprox(mean(abs.(residual)), 0, atol=1e-4)
 end
 
@@ -133,4 +133,4 @@ end
 
 @test lambdipoletest(256, 1e-3)
 
-@test stochasticforcingbudgetstest(256)
+@test stochasticforcingbudgetstest()

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -1,14 +1,20 @@
 import FourierFlows.TwoDTurb
+import FourierFlows.TwoDTurb: energy, enstrophy, dissipation, injection, drag
+
+# -----------------------------------------------------------------------------
+# TWODTURB's TEST FUNCTIONS
 
 cfl(prob) = maximum([maximum(abs.(prob.vars.U)), maximum(abs.(prob.vars.V))]*
               prob.ts.dt/prob.grid.dx)
 
+# LAMB DIPOLE TEST
 function lambdipoletest(n, dt; L=2π, Ue=1, Re=L/20, ν=0, nν=1, ti=L/Ue*0.01,
   nm=3, message=false)
 
   nt = round(Int, ti/dt)
 
-  prob = TwoDTurb.InitialValueProblem(nx=n, Lx=L, ν=ν, nν=nν, dt=dt, stepper="FilteredRK4")
+  prob = TwoDTurb.InitialValueProblem(nx=n, Lx=L, ν=ν, nν=nν, dt=dt,
+                                        stepper="FilteredRK4")
   x, y, q = prob.grid.X, prob.grid.Y, prob.vars.q # nicknames
 
   q0 = FourierFlows.lambdipole(Ue, Re, prob.grid)
@@ -38,4 +44,93 @@ function lambdipoletest(n, dt; L=2π, Ue=1, Re=L/20, ν=0, nν=1, ti=L/Ue*0.01,
   isapprox(Ue, mean(Ue_m[2:end]), rtol=1e-2)
 end
 
+
+# ISOTROPIC RING FORCING BUDGETS
+function stochasticforcingbudgets( ;n = 256, dt = 0.01, L=2π, ν=1e-7, nν=2,
+                                   μ = 1e-1, nμ = 0, message=false)
+
+  n, L  = 256, 2π
+  ν, nν = 1e-7, 2
+  μ, nμ = 1e-1, 0
+  dt, tf = 0.005, 0.2/μ
+  nt = round(Int, tf/dt)
+  ns = 1
+
+  # Forcing
+  kf, dkf = 12.0, 2.0
+  σ = 0.1
+
+  gr  = TwoDGrid(n, L)
+
+  force2k = exp.(-(sqrt.(gr.KKrsq)-kf).^2/(2*dkf^2))
+  force2k[gr.KKrsq .< 2.0^2 ] = 0
+  force2k[gr.KKrsq .> 20.0^2 ] = 0
+  force2k[gr.Kr.<2π/L] = 0
+  σ0 = FourierFlows.parsevalsum(force2k.*gr.invKKrsq/2.0, gr)/(gr.Lx*gr.Ly)
+  force2k .= σ/σ0 * force2k
+
+  srand(1234)
+
+  function calcF!(F, sol, t, s, v, p, g)
+    eta = exp.(2π*im*rand(size(sol)))/sqrt(s.dt)
+    eta[1, 1] = 0
+    @. F = eta .* sqrt(force2k)
+    nothing
+  end
+
+  prob = TwoDTurb.ForcedProblem(nx=n, Lx=L, ν=ν, nν=nν, μ=μ, nμ=nμ, dt=dt,
+   stepper="RK4", calcF=calcF!)
+
+  s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts;
+
+  TwoDTurb.set_q!(prob, 0*g.X)
+  E = Diagnostic(energy,      prob, nsteps=nt)
+  D = Diagnostic(dissipation, prob, nsteps=nt)
+  R = Diagnostic(drag,        prob, nsteps=nt)
+  I = Diagnostic(injection,   prob, nsteps=nt)
+  diags = [E, D, I, R]
+
+  # Step forward
+
+  stepforward!(prob, diags, round(Int, nt))
+
+  TwoDTurb.updatevars!(prob)
+
+  cfl = prob.ts.dt*maximum(
+    [maximum(v.V)/g.dx, maximum(v.U)/g.dy])
+
+  E, D, I, R = diags
+
+  t = round(μ*prob.state.t, 2)
+
+  i₀ = 1
+  dEdt = (E[(i₀+1):E.count] - E[i₀:E.count-1])/prob.ts.dt
+  ii = (i₀):E.count-1
+  ii2 = (i₀+1):E.count
+
+  # dEdt = I - D - R?
+  # If the Ito interpretation was used for the work
+  # then we need to add the drift term
+  # total = I[ii2]+σ - D[ii] - R[ii]      # Ito
+  total = I[ii2] - D[ii] - R[ii]        # Stratonovich
+
+  residual = dEdt - total
+
+
+
+  if message
+    @printf("step: %04d, t: %.1f, cfl: %.3f, time: %.2f s\n",
+            prob.step, prob.t, cfl, tc)
+  end
+
+  # println(mean(abs.(residual)))
+  isapprox(mean(abs.(residual)), 0, atol=1e-4)
+end
+
+# -----------------------------------------------------------------------------
+# Running the tests
+
+
 @test lambdipoletest(256, 1e-3)
+
+@test stochasticforcingbudgets()

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -53,6 +53,7 @@ function stochasticforcingbudgetstest( ; n = 256, dt = 0.01, L=2π, ν=1e-7, nν
   ν, nν = 1e-7, 2
   μ, nμ = 1e-1, 0
   dt, tf = 0.005, 0.1/μ
+  dt, tf = 0.0005, 0.02/μ
   nt = round(Int, tf/dt)
   ns = 1
 

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -46,8 +46,8 @@ end
 
 
 # ISOTROPIC RING FORCING BUDGETS
-function stochasticforcingbudgets( ;n = 256, dt = 0.01, L=2π, ν=1e-7, nν=2,
-                                   μ = 1e-1, nμ = 0, message=false)
+function stochasticforcingbudgetstest( n ; dt = 0.01, L=2π, ν=1e-7, nν=2,
+                                            μ = 1e-1, nμ = 0, message=false)
 
   n, L  = 256, 2π
   ν, nν = 1e-7, 2
@@ -133,4 +133,4 @@ end
 
 @test lambdipoletest(256, 1e-3)
 
-@test stochasticforcingbudgets()
+@test stochasticforcingbudgetstest(256)

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -1,5 +1,5 @@
 import FourierFlows.TwoDTurb
-import FourierFlows.TwoDTurb: energy, enstrophy, dissipation, injection, drag
+import FourierFlows.TwoDTurb: energy, enstrophy, dissipation, work, drag
 
 # -----------------------------------------------------------------------------
 # TWODTURB's TEST FUNCTIONS
@@ -87,8 +87,8 @@ function stochasticforcingbudgetstest( ; n = 256, dt = 0.01, L=2π, ν=1e-7, nν
   E = Diagnostic(energy,      prob, nsteps=nt)
   D = Diagnostic(dissipation, prob, nsteps=nt)
   R = Diagnostic(drag,        prob, nsteps=nt)
-  I = Diagnostic(injection,   prob, nsteps=nt)
-  diags = [E, D, I, R]
+  W = Diagnostic(work,        prob, nsteps=nt)
+  diags = [E, D, W, R]
 
   # Step forward
 
@@ -99,7 +99,7 @@ function stochasticforcingbudgetstest( ; n = 256, dt = 0.01, L=2π, ν=1e-7, nν
   cfl = prob.ts.dt*maximum(
     [maximum(v.V)/g.dx, maximum(v.U)/g.dy])
 
-  E, D, I, R = diags
+  E, D, W, R = diags
 
   t = round(μ*prob.state.t, 2)
 
@@ -108,11 +108,11 @@ function stochasticforcingbudgetstest( ; n = 256, dt = 0.01, L=2π, ν=1e-7, nν
   ii = (i₀):E.count-1
   ii2 = (i₀+1):E.count
 
-  # dEdt = I - D - R?
+  # dEdt = W - D - R?
   # If the Ito interpretation was used for the work
   # then we need to add the drift term
-  # total = I[ii2]+σ - D[ii] - R[ii]      # Ito
-  total = I[ii2] - D[ii] - R[ii]        # Stratonovich
+  # total = W[ii2]+σ - D[ii] - R[ii]      # Ito
+  total = W[ii2] - D[ii] - R[ii]        # Stratonovich
 
   residual = dEdt - total
 
@@ -122,8 +122,7 @@ function stochasticforcingbudgetstest( ; n = 256, dt = 0.01, L=2π, ν=1e-7, nν
     @printf("step: %04d, t: %.1f, cfl: %.3f, time: %.2f s\n",
             prob.step, prob.t, cfl, tc)
   end
-
-  println(mean(abs.(residual)))
+  # println(mean(abs.(residual)))
   isapprox(mean(abs.(residual)), 0, atol=1e-4)
 end
 

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -53,7 +53,6 @@ function stochasticforcingbudgetstest( ; n = 256, dt = 0.01, L=2π, ν=1e-7, nν
   ν, nν = 1e-7, 2
   μ, nμ = 1e-1, 0
   dt, tf = 0.005, 0.1/μ
-  dt, tf = 0.0005, 0.02/μ
   nt = round(Int, tf/dt)
   ns = 1
 


### PR DESCRIPTION
The PR resolves the puzzling issue regarding closing the energy budgets with stochastic forcing. The work done by the forcing is computed now using the Stratonovich interpretation which is valid both for stochastic as well as for deterministic forcing (see `injection` function within `twodturb.jl`).