### PR TITLE
A test for the nonlinear terms in TwoDturb module

### DIFF
--- a/examples/twodturb/testtwodturb_olivier.jl
+++ b/examples/twodturb/testtwodturb_olivier.jl
@@ -1,0 +1,129 @@
+using PyPlot, FourierFlows
+import FourierFlows.TwoDTurb
+import FourierFlows.TwoDTurb: energy, enstrophy, dissipation, work, drag
+
+n, L  = 128, 2π
+ν, nν = 1e-2, 1
+μ, nμ = 0.0, 0
+dt, tf = 0.02, 250
+nt = round(Int, tf/dt)
+ns = 40
+
+gr  = TwoDGrid(n, L)
+
+
+remainder = -0.25*ν*(75.0*cos.(gr.Y) + 169.0*cos.(3*gr.Y)).*sin.(2*gr.X)- 12*cos.(gr.Y).^3.*sin.(4*gr.X).*sin.(gr.Y)
+
+# figure(3)
+# pcolormesh(gr.X, gr.Y, remainder)
+
+remainderh = rfft(remainder);
+# Forcing
+function calcF!(Fh, sol, t, s, v, p, g)
+   Fh .= remainderh
+  nothing
+end
+
+prob = TwoDTurb.ForcedProblem(nx=n, Lx=L, ν=ν, nν=nν, μ=μ, nμ=nμ, dt=dt,
+  stepper="ETDRK4", calcF=calcF!)
+
+s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts;
+
+TwoDTurb.set_q!(prob, 0*g.X)
+E = Diagnostic(energy,      prob, nsteps=nt)
+D = Diagnostic(dissipation, prob, nsteps=nt)
+R = Diagnostic(drag,        prob, nsteps=nt)
+W = Diagnostic(work,        prob, nsteps=nt)
+diags = [E, D, W, R]
+
+
+function makeplot(prob, diags)
+
+  TwoDTurb.updatevars!(prob)
+
+  E, D, W, R = diags
+
+  x, y = prob.grid.X, prob.grid.Y
+
+  t = round(prob.state.t, 2)
+  sca(axs[1]); cla()
+  pcolormesh(x, y, prob.vars.q - (-0.5*cos.(y).*sin.(2x).*(1+13*cos.(2y)) ) )
+  xlabel(L"$x$")
+  ylabel(L"$y$")
+  title("\$\\nabla^2\\psi(x,y,\\mu t= $t )\$")
+  axis("square")
+
+
+  sca(axs[3]); cla()
+
+  i₀ = 1
+  dEdt = (E[(i₀+1):E.count] - E[i₀:E.count-1])/prob.ts.dt
+  ii = (i₀):E.count-1
+  ii2 = (i₀+1):E.count
+
+  # dEdt = W - D - R?
+
+  # If the Ito interpretation was used for the work
+  # then we need to add the drift term
+  # total = W[ii2]+σ - D[ii] - R[ii]      # Ito
+  total = W[ii2] - D[ii] - R[ii]        # Stratonovich
+
+
+  residual = dEdt - total
+
+  # If the Ito interpretation was used for the work
+  # then we need to add the drift term: I[ii2] + σ
+  plot(E.time[ii], W[ii2], label=L"work ($W$)")   # Ito
+  plot(E.time[ii], -R[ii], label=L"drag ($D=2\mu E$)")
+  plot(E.time[ii], 0*E.time[ii], "k:", linewidth=0.5)
+  ylabel("Energy sources and sinks")
+  xlabel(L"$t$")
+  legend(fontsize=10)
+
+  sca(axs[2]); cla()
+  plot(E.time[ii], total[ii], label=L"computed $W-D$")
+  plot(E.time[ii], dEdt, "--k", label=L"numerical $dE/dt$")
+  ylabel(L"$dE/dt$")
+  xlabel(L"$t$")
+  legend(fontsize=10)
+
+  sca(axs[4]); cla()
+  plot(E.time[ii], residual, "c-", label=L"residual $dE/dt$ = computed $-$ numerical")
+  xlabel(L"$\mu t$")
+  legend(fontsize=10)
+
+  residual
+end
+
+fig, axs = subplots(ncols=2, nrows=2, figsize=(12, 8))
+
+# Step forward
+for i = 1:ns
+  tic()
+
+  stepforward!(prob, diags, round(Int, nt/ns))
+  tc = toq()
+
+  TwoDTurb.updatevars!(prob)
+  # saveoutput(out)
+
+  cfl = prob.ts.dt*maximum(
+    [maximum(v.V)/g.dx, maximum(v.U)/g.dy])
+
+  res = makeplot(prob, diags)
+  pause(0.01)
+
+  @printf("step: %04d, t: %.1f, cfl: %.3f, time: %.2f s\n",
+    prob.step, prob.t, cfl, tc)
+
+  # savename = @sprintf("./plots/stochastictest_kf%d_%06d.png", kf, prob.step)
+  # savefig(savename, dpi=240)
+end
+
+# savename = @sprintf("./plots/stochastictest_kf%d_%06d.png", kf, prob.step)
+# savefig(savename, dpi=240)
+
+# savediagnostic(E, "energy", out.filename)
+# savediagnostic(D, "dissipation", out.filename)
+# savediagnostic(W, "work", out.filename)
+# savediagnostic(R, "drag", out.filename)

--- a/sandbox/test_jacobiantwodturb.jl
+++ b/sandbox/test_jacobiantwodturb.jl
@@ -2,12 +2,13 @@ using PyPlot, FourierFlows
 import FourierFlows.TwoDTurb
 import FourierFlows.TwoDTurb: energy, enstrophy, dissipation, work, drag
 
-# This tests the nonlinear terms in the twodturb module; it works as follows
-# assume a solution ψ_guess for the unforced case. Then we insert the solution
-# in the equation and compute the remainder analytically, e.g.:
-# remainder = -(∂ζ_guess/∂t + J(ψ_guess, ζ_guess) - νΔζ_guess)
-# Finally we use remainder as forcing. Then ζ_guess should be a solution of
-# the forced problem.
+# Tests the advection term in the twodturb module by timestepping a
+# test problem with timestep dt and timestepper identified by the string stepper.
+# The test problem is derived by picking a solution ζf (with associated
+# streamfunction ψf) for which the advection term J(ψf, ζf) is non-zero. Next, a
+# forcing Ff is derived according to Ff = ∂ζf/∂t + J(ψf, ζf) - νΔζf. One solution
+# to the vorticity equation forced by this Ff is then ζf. (This solution may not
+# be realized, at least at long times, if it is unstable.)
 
 n, L  = 128, 2π
 ν, nν = 1e-2, 1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -172,7 +172,6 @@ function lambdipole(Ue::Real, R::Real, g::TwoDGrid; center=(nothing, nothing))
   end
 
   # Wavenumber corresponding to radius R and the first bessel func zero.
-  # k = 3.8317 / R
   k = 3.8317059702075123156 / R
   q0 = -2*Ue*k/SpecialFunctions.besselj(0, k*R)
 

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -132,11 +132,11 @@ end
 
 Tests the advection term in the twodturb module by timestepping a
 test problem with timestep dt and timestepper identified by the string stepper.
-The test problem is derived by picking a solution ζf (with associated streamfunction ψf) 
-for which the advection term J(ψf, ζf) is non-zero. Next, a forcing Ff is derived
-according to Ff = ∂ζf/∂t + J(ψf, ζf) - νΔζf. One solution to the vorticity
-equation forced by this Ff is then ζf (this solution may not be realized, 
-at least at long times, if it is unstable).
+The test problem is derived by picking a solution ζf (with associated
+streamfunction ψf) for which the advection term J(ψf, ζf) is non-zero. Next, a
+forcing Ff is derived according to Ff = ∂ζf/∂t + J(ψf, ζf) - νΔζf. One solution
+to the vorticity equation forced by this Ff is then ζf. (This solution may not
+be realized, at least at long times, if it is unstable.)
 """
 function testnonlinearterms(dt, stepper; n=128, L=2π, ν=1e-2, nν=1,
                                          μ=0.0, nμ=0, message=false)
@@ -154,13 +154,13 @@ function testnonlinearterms(dt, stepper; n=128, L=2π, ν=1e-2, nν=1,
   psif = @. sin(2x)*cos(2y) + 2sin(x)*cos(3y)
   qf = @. -8sin(2x)*cos(2y) - 20sin(x)*cos(3y)
 
-  Ff = @. -( 
-    ν*( 64sin(2x)*cos(2y) + 200sin(x)*cos(3y) ) 
+  Ff = @. -(
+    ν*( 64sin(2x)*cos(2y) + 200sin(x)*cos(3y) )
     + 8*( cos(x)*cos(3y)*sin(2x)*sin(2y) - 3cos(2x)*cos(2y)*sin(x)*sin(3y) )
   )
 
   Ffh = rfft(Ff)
-  
+
   # Forcing
   function calcF!(Fh, sol, t, s, v, p, g)
     Fh .= Ffh
@@ -192,4 +192,5 @@ end
 
 # Run the tests
 @test testnonlinearterms(0.0005, "ForwardEuler")
+@test lambdipoletest(256, 1e-3)
 @test stochasticforcingbudgetstest()

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -192,11 +192,4 @@ end
 
 # Run the tests
 @test testnonlinearterms(0.0005, "ForwardEuler")
-@test testnonlinearterms(0.001, "FilteredForwardEuler")
-@test testnonlinearterms(0.001, "AB3")
-@test testnonlinearterms(0.002, "FilteredAB3")
-@test testnonlinearterms(0.005, "RK4")
-@test testnonlinearterms(0.01, "FilteredRK4")
-@test testnonlinearterms(0.005, "ETDRK4")
-@test testnonlinearterms(0.01, "FilteredETDRK4")
 @test stochasticforcingbudgetstest()

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -136,7 +136,7 @@ function testnonlinearterms( dt, stepper; n = 128, L=2π, ν=1e-2, nν=1,
 # Assume a solution ψ_guess for the unforced case. Then insert the solution
 # in the equation and compute the remainder analytically, e.g.:
 # remainder = -(∂ζ_guess/∂t + J(ψ_guess, ζ_guess) - νΔζ_guess)
-# Finally we use remainder as forcing. Then ζ_guess should be a solution of
+# Finally use remainder as forcing. Then ζ_guess should be a solution of
 # the forced problem.
 
   n, L  = 128, 2π

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -132,8 +132,8 @@ end
 function testnonlinearterms( dt, stepper; n = 128, L=2π, ν=1e-2, nν=1,
                                    μ = 0.0, nμ = 0, message=false)
 
-# This tests the nonlinear terms in the twodturb module; it works as follows
-# assume a solution ψ_guess for the unforced case. Then we insert the solution
+# This tests the nonlinear terms in the twodturb module; it works as follows:
+# Assume a solution ψ_guess for the unforced case. Then insert the solution
 # in the equation and compute the remainder analytically, e.g.:
 # remainder = -(∂ζ_guess/∂t + J(ψ_guess, ζ_guess) - νΔζ_guess)
 # Finally we use remainder as forcing. Then ζ_guess should be a solution of


### PR DESCRIPTION
This is the test proposed by @oliasselin.
It assumes a solution `ψ_g=sin(2x)cos.(2y)+2sin(x)cos.(3y)`, computes the remainder
`R=-(∂ζ_g/∂t + J(ψ_g, ζ_g) - νΔζ_g)`,
and then uses `R` as forcing in a forced twodturb problem. Then,`ψ_g` is a steady solution of the forced problem; the test time-steps the forced problem for `t=1` starting from `ζ(t=0)=ζ_g` and reports `|ζ(t=1)-ζ_g|`.