### PR TITLE
Updates tests to use isapprox() instead of norm()

### DIFF
--- a/sandbox/test_timesteppers_convergence.jl
+++ b/sandbox/test_timesteppers_convergence.jl
@@ -1,5 +1,6 @@
 using PyPlot
 using FourierFlows
+import FourierFlows.BarotropicQG
 
 
 function test_baroQG_RossbyWave(stepper, dt, nsteps, g, p, v, eq)
@@ -25,7 +26,7 @@ function test_baroQG_RossbyWave(stepper, dt, nsteps, g, p, v, eq)
     ζ_theory = ampl*cos.(kwave*(g.X-ω/kwave*s.t)).*cos.(lwave*g.Y)
     # println(norm(ζ_theory - v.zeta)/norm(ζ_theory))
     # isapprox(ζ_theory, v.zeta, rtol=g.nx*g.ny*nsteps*1e-12)
-    residual = norm(ζ_theory - v.zeta)/norm(ζ_theory)
+    residual = vecnorm(ζ_theory - v.zeta)/vecnorm(ζ_theory)
     residual
 end
 

--- a/test/test_barotropicqg.jl
+++ b/test/test_barotropicqg.jl
@@ -26,7 +26,6 @@ function test_baroQG_RossbyWave(stepper, dt, nsteps, g, p, v, eq)
     BarotropicQG.updatevars!(prob)
 
     ζ_theory = ampl*cos.(kwave*(g.X-ω/kwave*s.t)).*cos.(lwave*g.Y)
-    # println(norm(ζ_theory - v.zeta)/norm(ζ_theory))
     isapprox(ζ_theory, v.zeta, rtol=g.nx*g.ny*nsteps*1e-12)
 end
 

--- a/test/test_fft.jl
+++ b/test/test_fft.jl
@@ -91,57 +91,57 @@ end
 # -----------------------------------------------------------------------------
 # FFT's TEST FUNCTIONS
 
-tolerance = 1e-12
+rtol = 1e-12
 
 function test_fft_cosmx(g::OneDGrid)
     f1, f1h, f1hr, f1hr_mul, f1h_th, f1hr_th = create_testfuncs(g)
-    norm(f1h-f1h_th)/norm(f1h_th) < tolerance
+    isapprox(f1h, f1h_th, rtol=rtol)
 end
 
 function test_rfft_cosmx(g::OneDGrid)
     f1, f1h, f1hr, f1hr_mul, f1h_th, f1hr_th = create_testfuncs(g)
-    norm(f1hr-f1hr_th)/norm(f1hr_th) < tolerance
+    isapprox(f1hr, f1hr_th, rtol=rtol)
 end
 
 function test_rfft_AmulB_cosmx(g::OneDGrid)
     f1, f1h, f1hr, f1hr_mul, f1h_th, f1hr_th = create_testfuncs(g)
-    norm(f1hr_mul-f1hr_th)/norm(f1hr_th) < tolerance
+    isapprox(f1hr_mul, f1hr_th, rtol=rtol)
 end
 
 function test_fft_cosmxcosny(g::TwoDGrid)
     f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
-    norm(f1h-f1h_th)/norm(f1h_th) < tolerance
+    isapprox(f1h, f1h_th, rtol=rtol)
 end
 
 function test_rfft_cosmxcosny(g::TwoDGrid)
     f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
-    norm(f1hr-f1hr_th)/norm(f1hr_th) < tolerance
+    isapprox(f1hr, f1hr_th, rtol=rtol)
 end
 
 function test_rfft_AmulB_cosmxcosny(g::TwoDGrid)
     f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
-    norm(f1hr_mul-f1hr_th)/norm(f1hr_th) < tolerance
+    isapprox(f1hr_mul, f1hr_th, rtol=rtol)
 end
 
 function test_fft_sinmxny(g::TwoDGrid)
     f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
-    norm(f2h-f2h_th)/norm(f2h_th) < tolerance
+    isapprox(f2h, f2h_th, rtol=rtol)
 end
 
 function test_rfft_sinmxny(g::TwoDGrid)
     f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
-    norm(f2hr-f2hr_th)/norm(f2hr_th) < tolerance
+    isapprox(f2hr, f2hr_th, rtol=rtol)
 end
 
 function test_rfft_AmulB_sinmxny(g::TwoDGrid)
     f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
-    norm(f2hr_mul-f2hr_th)/norm(f2hr_th) < tolerance
+    isapprox(f2hr_mul, f2hr_th, rtol=rtol)
 end
 
 # Test 1D grid

--- a/test/test_ifft.jl
+++ b/test/test_ifft.jl
@@ -4,13 +4,13 @@
 # -----------------------------------------------------------------------------
 # IFFT's TEST FUNCTIONS
 
-tolerance = 1e-12
+rtol = 1e-12
 
 function test_ifft_cosmx(g::OneDGrid)
     # test fft for cos(mx+φ)
     f1, f1h, f1hr, f1hr_mul, f1h_th, f1hr_th = create_testfuncs(g)
     f1b = real(ifft(f1h))
-    norm(f1-f1b)/norm(f1) < tolerance
+    isapprox(f1, f1b, rtol=rtol)
 end
 
 function test_irfft_cosmx(g::OneDGrid)
@@ -19,7 +19,7 @@ function test_irfft_cosmx(g::OneDGrid)
     f1hr_c = deepcopy(f1hr)
     # deepcopy is needed because FFTW irfft messes up with input!
     f1b = irfft(f1hr_c, nx)
-    norm(f1-f1b)/norm(f1) < tolerance
+    isapprox(f1, f1b, rtol=rtol)
 end
 
 function test_irfft_AmulB_cosmx(g::OneDGrid)
@@ -29,7 +29,7 @@ function test_irfft_AmulB_cosmx(g::OneDGrid)
     # deepcopy is needed because FFTW irfft messes up with input!
     f1b = Array{Float64}(g.nx)
     A_mul_B!( f1b, g.irfftplan, f1hr_c )
-    norm(f1-f1b)/norm(f1) < tolerance
+    isapprox(f1, f1b, rtol=rtol)
 end
 
 function test_ifft_cosmxcosny(g::TwoDGrid)
@@ -37,7 +37,7 @@ function test_ifft_cosmxcosny(g::TwoDGrid)
     f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
     f1b = real(ifft(f1h))
-    norm(f1-f1b)/norm(f1) < tolerance
+    isapprox(f1, f1b, rtol=rtol)
 end
 
 function test_irfft_cosmxcosny(g::TwoDGrid)
@@ -47,7 +47,7 @@ function test_irfft_cosmxcosny(g::TwoDGrid)
     f1hr_c = deepcopy(f1hr)
     # deepcopy is needed because FFTW irfft messes up with input!
     f1b = irfft(f1hr_c, nx)
-    norm(f1-f1b)/norm(f1) < tolerance
+    isapprox(f1, f1b, rtol=rtol)
 end
 
 function test_irfft_AmulB_cosmxcosny(g::TwoDGrid)
@@ -58,7 +58,7 @@ function test_irfft_AmulB_cosmxcosny(g::TwoDGrid)
     # deepcopy is needed because FFTW irfft messes up with input!
     f1b = Array{Float64}(g.nx, g.ny)
     A_mul_B!( f1b, g.irfftplan, f1hr_c )
-    norm(f1-f1b)/norm(f1) < tolerance
+    isapprox(f1, f1b, rtol=rtol)
 end
 
 function test_ifft_sinmxny(g::TwoDGrid)
@@ -68,7 +68,7 @@ function test_ifft_sinmxny(g::TwoDGrid)
     f2hr_c = deepcopy(f2hr)
     # deepcopy is needed because FFTW irfft messes up with input!
     f2b3 = irfft(f2hr_c, g.nx)
-    norm(f2-f2b3)/norm(f2) < tolerance
+    isapprox(f2, f2b3, rtol=rtol)
 end
 
 function test_irfft_sinmxny(g::TwoDGrid)
@@ -76,7 +76,7 @@ function test_irfft_sinmxny(g::TwoDGrid)
     f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
     f2b4 = real(ifft(f2h))
-    norm(f2-f2b4)/norm(f2) < tolerance
+    isapprox(f2, f2b4, rtol=rtol)
 end
 
 function test_irfft_AmulB_sinmxny(g::TwoDGrid)
@@ -86,8 +86,8 @@ function test_irfft_AmulB_sinmxny(g::TwoDGrid)
     f2hr_c = deepcopy(f2hr)
     # deepcopy is needed because FFTW irfft messes up with input!
     f2b = Array{Float64}(g.nx, g.ny)
-    A_mul_B!( f2b, g.irfftplan, f2hr_c )
-    norm(f2-f2b)/norm(f2) < tolerance
+    A_mul_B!(f2b, g.irfftplan, f2hr_c)
+    isapprox(f2, f2b, rtol=rtol)
 end
 
 

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -144,7 +144,7 @@ function testnonlinearterms(dt, stepper; n=128, L=2π, nu=1e-2, nnu=1, mu=0.0, n
   # Step forward
   stepforward!(prob, round(Int, nt))
   TwoDTurb.updatevars!(prob)
-  isapprox(norm(v.q - qf)/norm(qf), 0, atol=1e-13)
+  isapprox(v.q, qf, rtol=1e-13)
 end
 
 # Run the tests

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,6 +1,6 @@
 # import FourierFlows.TwoDTurb
 
-test_fftwavenums() = FourierFlows.fftwavenums(6; L=2π) == [0, 1, 2, 3, -2, -1]  
+test_fftwavenums() = FourierFlows.fftwavenums(6; L=2π) == [0, 1, 2, 3, -2, -1]
 
 function test_domainaverage(n; xdir=true)
   g = TwoDGrid(n, 2π)
@@ -64,7 +64,9 @@ end
 Compute the J(a,b) and compare with analytic_answer.
 """
 function test_jacobian(a, b, analytic_answer, grid)
-    isapprox(norm(FourierFlows.jacobian(a, b, grid)), norm(analytic_answer); 
+    # it's important to use atol for this test since when analytic_answer=0
+    # the rtol is not conclusive (e.g., isapprox(1e-5, 0, rtol=1e-10) is false)
+    isapprox(FourierFlows.jacobian(a, b, grid), analytic_answer;
              atol=g.nx*g.ny*1e-14)
 end
 
@@ -86,9 +88,9 @@ k0, l0 = 2π/Lx, 2π/Ly
 # Real and complex-valued functions
 σ = 0.5
 f1 = exp.(-(x.^2 + y.^2)/(2σ^2))
-f2 = exp.( im*(2k0*x + 3l0*y.^2) ).*( 
+f2 = exp.( im*(2k0*x + 3l0*y.^2) ).*(
       exp.(-(x.^2 + y.^2)/(2σ^2)) + 2im*exp.(-(x.^2 + y.^2)/(5σ^2)) )
-                                        
+
 # Sine waves
 k1, l1 = 2*k0, 6*l0
 k2, l2 = 3*k0, -3*l0

--- a/test/test_verticallycosineboussinesq.jl
+++ b/test/test_verticallycosineboussinesq.jl
@@ -3,12 +3,12 @@ import FourierFlows.VerticallyCosineBoussinesq
 cfl(prob) = maximum([maximum(abs.(prob.vars.U)), maximum(abs.(prob.vars.V))]*
               prob.ts.dt/prob.grid.dx)
 
-function test_lambdipole(n, dt; L=2π, Ue=1, Re=L/20, nu0=0, nnu0=1, 
+function test_lambdipole(n, dt; L=2π, Ue=1, Re=L/20, nu0=0, nnu0=1,
   ti=L/Ue*0.01, nm=3, message=false, atol=1e-2)
 
   nt = round(Int, ti/dt)
 
-  prob = VerticallyCosineBoussinesq.Problem(nx=n, Lx=L, 
+  prob = VerticallyCosineBoussinesq.Problem(nx=n, Lx=L,
     nu0=nu0, nnu0=nnu0, dt=dt, stepper="FilteredRK4")
   x, y, Z = prob.grid.X, prob.grid.Y, prob.vars.Z # nicknames
 
@@ -22,7 +22,7 @@ function test_lambdipole(n, dt; L=2π, Ue=1, Re=L/20, nu0=0, nnu0=1,
   for i = 1:nm
     tic()
     stepforward!(prob, nt)
-    VerticallyCosineBoussinesq.updatevars!(prob)  
+    VerticallyCosineBoussinesq.updatevars!(prob)
     xZ[i] = mean(abs.(Z).*x) / mean(abs.(Z))
 
     if i > 1
@@ -73,7 +73,7 @@ function testnonlinearterms(dt, stepper; n=128, L=2π, nu=1e-2, nnu=1, mu=0.0, n
   # Step forward
   stepforward!(prob, round(Int, nt))
   VerticallyCosineBoussinesq.updatevars!(prob)
-  isapprox(norm(v.Z - Zf)/norm(Zf), 0, atol=1e-13)
+  isapprox(v.Z, Zf, rtol=1e-13)
 end
 
 
@@ -95,7 +95,7 @@ function test_groupvelocity(kw; n=128, L=2π, f=1.0, N=1.0, m=4.0, uw=1e-2, rtol
 
   t₋₁ = prob.t
   xw₋₁, yw₋₁ = wavecentroid(prob)
-    
+
   stepforward!(prob, nt)
   VerticallyCosineBoussinesq.updatevars!(prob)
   xw, yw = wavecentroid(prob)


### PR DESCRIPTION
This PR addresses the issue #61 raised by @stevengj. The use of `norm()` function in the tests is abolished; the updated tests use `isapprox()`.