### PR TITLE
Updates BarotropicQG module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
 julia:
   # - nightly
   # - 0.6.0
-  - 0.6.2
+  - 0.6.3
 
 before_script:
  - julia -e 'Pkg.add("JLD2"); Pkg.add("SpecialFunctions"); Pkg.add("CuArrays");'

--- a/examples/barotropicqg/ACConelayer.jl
+++ b/examples/barotropicqg/ACConelayer.jl
@@ -4,37 +4,35 @@ using FourierFlows, PyPlot, JLD2
 import FourierFlows.BarotropicQG
 import FourierFlows.BarotropicQG: energy, energy00, enstrophy, enstrophy00
 
-nx  = 512
-ν  = 8.0e-10
-νn = 2
-f0 = -1.0
+# Numerical parameters and time-stepping parameters
+nx  = 512      # 2D resolution = nx^2
+stepper = "FilteredETDRK4"   # timestepper
+dt  = 2e-2     # timestep
+nsteps = 20000 # total number of time-steps
+nsubs  = 500   # number of time-steps for plotting
+               # (nsteps must be multiple of nsubs)
 
-β = 1.4015
-Lx = 2π
-μ = 1.0e-2
-F = 0.0012
+# Physical parameters
+Lx  = 2π       # domain size
+nu  = 8.0e-10  # viscosity
+nnu = 2        # viscosity order
+f0  = -1.0     # Coriolis parameter
+beta = 1.4015  # the y-gradient of planetary PV
+mu   = 1.0e-2  # linear drag
+   F = 0.0012  # normalized wind stress forcing on domain-averaged
+               # zonal flow U(t) flow
 
-FU(t) = F
+# Topographic PV
+eta(x, y) = 2*cos.(10x).*cos.(10y)
 
-η(x, y) = 2*cos.(10x).*cos.(10y)
-
-
-g  = BarotropicQG.Grid(nx, Lx)
-p  = BarotropicQG.Params(g, f0, β, FU, η, μ, ν, νn)
-v  = BarotropicQG.Vars(g)
-eq = BarotropicQG.Equation(p, g)
-
-
-# Time-stepping
-dt  = 2e-2
-nsteps = 20000
-nsubs  = 500
+# Forcing on the domain-averaged U equation
+calcFU(t) = F
 
 
-# ts = FilteredETDRK4TimeStepper(dt, eq.LC, g)
-ts = ETDRK4TimeStepper(dt, eq.LC)
-prob = FourierFlows.Problem(g, v, p, eq, ts)
-s = prob.state
+# Initialize problem
+prob = BarotropicQG.ForcedProblem(nx=nx, Lx=Lx, f0=f0, beta=beta, eta=eta,
+                  calcFU=calcFU, nu=nu, nnu=nnu, mu=mu, dt=dt, stepper=stepper)
+s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts;
 
 
 # Files
@@ -67,7 +65,8 @@ out = Output(prob, filename, (:sol, get_sol), (:u, get_u))
 
 
 function plot_output(prob, fig, axs; drawcolorbar=false)
-  # Plot the vorticity field and the evolution of energy and enstrophy.
+
+  # Plot the PV field and the evolution of energy and enstrophy.
 
   s, v, p, g = prob.state, prob.vars, prob.params, prob.grid
   BarotropicQG.updatevars!(prob)
@@ -76,24 +75,27 @@ function plot_output(prob, fig, axs; drawcolorbar=false)
   pcolormesh(g.X, g.Y, v.q)
   axis("square")
   xlim(0, 2)
+  xticks(0:0.5:2)
   ylim(0, 2)
-  # axis("off")
+  yticks(0:0.5:2)
+  title(L"$\nabla^2\psi + \eta$ (part of the domain)")
   if drawcolorbar==true
     colorbar()
   end
 
   sca(axs[2])
   cla()
-  plot(μ*E.time[1:E.prob.step], E.data[1:prob.step], label=L"$E_{\psi}$")
-  plot(μ*E.time[1:E00.prob.step], E00.data[1:prob.step], label=L"$E_U$")
+  plot(mu*E.time[1:E.prob.step], E.data[1:prob.step], label=L"$E_{\psi}$")
+  plot(mu*E.time[1:E00.prob.step], E00.data[1:prob.step], label=L"$E_U$")
+
   xlabel(L"\mu t")
   ylabel(L"E")
   legend()
 
   sca(axs[3])
   cla()
-  plot(μ*Q.time[1:Q.prob.step], Q.data[1:prob.step], label=L"$Q_{\psi}$")
-  plot(μ*Q00.time[1:Q00.prob.step], Q00.data[1:prob.step], label=L"$Q_U$")
+  plot(mu*Q.time[1:Q.prob.step], Q.data[1:prob.step], label=L"$Q_{\psi}$")
+  plot(mu*Q00.time[1:Q00.prob.step], Q00.data[1:prob.step], label=L"$Q_U$")
   xlabel(L"\mu t")
   ylabel(L"Q")
   legend()

--- a/examples/barotropicqg/ACConelayer.jl
+++ b/examples/barotropicqg/ACConelayer.jl
@@ -23,14 +23,14 @@ mu   = 1.0e-2  # linear drag
                # zonal flow U(t) flow
 
 # Topographic PV
-eta(x, y) = 2*cos.(10x).*cos.(10y)
+topoPV(x, y) = 2*cos.(10x).*cos.(10y)
 
 # Forcing on the domain-averaged U equation
 calcFU(t) = F
 
 
 # Initialize problem
-prob = BarotropicQG.ForcedProblem(nx=nx, Lx=Lx, f0=f0, beta=beta, eta=eta,
+prob = BarotropicQG.ForcedProblem(nx=nx, Lx=Lx, f0=f0, beta=beta, eta=topoPV,
                   calcFU=calcFU, nu=nu, nnu=nnu, mu=mu, dt=dt, stepper=stepper)
 s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts;
 

--- a/examples/barotropicqg/decayingbetaturb.jl
+++ b/examples/barotropicqg/decayingbetaturb.jl
@@ -5,41 +5,31 @@ import FourierFlows.BarotropicQG: energy, enstrophy
 
 # Physical parameters
 nx  = 256
-Lx = 2π     # domain size
-ν  = 0e-05  # viscosity
-νn = 1      # viscosity order
+Lx  = 2π     # domain size
+nu  = 0e-05  # viscosity
+nnu = 1      # viscosity order
 
-f0 = 1.0    # Coriolis parameter
-β = 15.0    # planetary PV gradient
-μ = 0e-1    # bottom drag
-
-F = 0.0     # large-scale flow U(t) forcing;
-FU(t) = F   # not applicable here
-η(x, y) = 0*x   # bottom topography
-
-g  = BarotropicQG.Grid(nx, Lx)
-p  = BarotropicQG.Params(g, f0, β, FU, η, μ, ν, νn)
-v  = BarotropicQG.Vars(g)
-eq = BarotropicQG.Equation(p, g)
-
-
+f0   = 1.0    # Coriolis parameter
+beta = 15.0    # planetary PV gradient
+mu   = 0e-1    # bottom drag
 
 # Time-stepping
+stepper = "FilteredETDRK4"
 dt = 0.02
 nsteps = 8000
 nsubs  = 500
 
 
-ts = FourierFlows.autoconstructtimestepper("FilteredETDRK4", dt, eq.LC, g)
-prob = FourierFlows.Problem(g, v, p, eq, ts)
-s = prob.state
+prob = BarotropicQG.InitialValueProblem(nx=nx, Lx=Lx, f0=f0, beta=beta, nu=nu,
+nnu=nnu, mu=mu, dt=dt, stepper=stepper)
+s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts;
 
 
 # Files
 filepath = "."
 plotpath = "./plots"
 plotname = "testplots"
-filename = joinpath(filepath, "testdata.jld2")
+filename = joinpath(filepath, "decayingbetaturb.jld2")
 
 # File management
 if isfile(filename); rm(filename); end

--- a/examples/barotropicqg/forcedbetaturb.jl
+++ b/examples/barotropicqg/forcedbetaturb.jl
@@ -148,7 +148,7 @@ startwalltime = time()
 
 while prob.step < nsteps
   stepforward!(prob, diags, nsubs)
-  cfl = maximum(sqrt.(v.u.^2+v.v.^2))*ts.dt/g.dx
+  cfl = prob.ts.dt*maximum([maximum(v.v)/g.dx, maximum(v.u)/g.dy])
 
   # Message
   log = @sprintf("step: %04d, t: %d, cfl: %.2f, E: %.4f, Q: %.4f, τ: %.2f min",

--- a/examples/twodturb/Chan2012.jl
+++ b/examples/twodturb/Chan2012.jl
@@ -18,7 +18,7 @@ norm = n^2/4
 function calcF!(F, sol, t, s, v, p, g)
   if t == s.t # not a substep
     F .= 0.0
-    θ, ξ = 2π*rand(2) 
+    θ, ξ = 2π*rand(2)
     i₁ = round(Int, abs(ki*cos(θ))) + 1
     j₁ = round(Int, abs(ki*sin(θ))) + 1 # j₁ >= 1
     j₂ = n + 2 - j₁ # e.g. j₁ = 1 => j₂ = nl+1
@@ -39,8 +39,8 @@ prob = TwoDTurb.ForcedProblem(nx=n, Lx=L, nu=nu, nnu=nnu, mu=mu, dt=dt, calcF=ca
 E = Diagnostic(energy, prob, nsteps=round(Int, tf/dt))
 Z = Diagnostic(enstrophy, prob, nsteps=round(Int, tf/dt))
 D = Diagnostic(dissipation, prob, nsteps=round(Int, tf/dt))
-I = Diagnostic(injection, prob, nsteps=round(Int, tf/dt))
-diags = [E, Z, D, I]
+W = Diagnostic(work, prob, nsteps=round(Int, tf/dt))
+diags = [E, Z, D, W]
 
 # Step forward
 fig, axs = subplots(ncols=3, figsize=(12, 4))
@@ -48,7 +48,7 @@ for i = 1:round(Int, tf/dt/ndp)
 
   tic()
   stepforward!(prob, diags, ndp)
-  TwoDTurb.updatevars!(prob)  
+  TwoDTurb.updatevars!(prob)
 
   cfl = prob.ts.dt*maximum([maximum(prob.vars.V)/prob.grid.dx, maximum(prob.vars.U)/prob.grid.dy])
   @printf("step: %04d, t: %.1f, cfl: %.2f, time: %.3f s\n", prob.step, prob.t, cfl, toq())
@@ -64,7 +64,7 @@ for i = 1:round(Int, tf/dt/ndp)
   plot(E.time[ii], dEdt)
   plot(E.time[ii], -D[ii])
   plot(E.time[ii], -mu*E[ii])
-  plot(E.time[ii], I[ii], "k.", markersize=0.1)
+  plot(E.time[ii], W[ii], "k.", markersize=0.1)
   xlabel(L"t")
 
   sca(axs[3]); cla()
@@ -72,7 +72,7 @@ for i = 1:round(Int, tf/dt/ndp)
   xlabel(L"t")
   ylabel(L"E")
 
-  axs[1][:tick_params](bottom=false, labelbottom=false, 
+  axs[1][:tick_params](bottom=false, labelbottom=false,
     left=false, labelleft=false)
 
   pause(0.01)

--- a/examples/twodturb/constantforcing.jl
+++ b/examples/twodturb/constantforcing.jl
@@ -1,6 +1,6 @@
 using PyPlot, FourierFlows
 import FourierFlows.TwoDTurb
-import FourierFlows.TwoDTurb: energy, dissipation, injection, drag
+import FourierFlows.TwoDTurb: energy, dissipation, work, drag
 
   n, L  =  128, 2π
 nu, nnu = 2e-4,  1
@@ -33,8 +33,8 @@ function runtest(prob, nt)
   E = Diagnostic(energy,      prob, nsteps=nt)
   D = Diagnostic(dissipation, prob, nsteps=nt)
   R = Diagnostic(drag,        prob, nsteps=nt)
-  I = Diagnostic(injection,   prob, nsteps=nt)
-  diags = [E, D, I, R]
+  W = Diagnostic(work,   prob, nsteps=nt)
+  diags = [E, D, W, R]
 
   tic()
   stepforward!(prob, diags, round(Int, nt))
@@ -44,8 +44,8 @@ function runtest(prob, nt)
 end
 
 function makeplot(prob, diags)
-  E, D, I, R = diags
-  TwoDTurb.updatevars!(prob)  
+  E, D, W, R = diags
+  TwoDTurb.updatevars!(prob)
 
   close("all")
   E, D, I, R = diags
@@ -62,14 +62,14 @@ function makeplot(prob, diags)
   dEdt = (E[(i₀+1):E.count] - E[i₀:E.count-1])/prob.ts.dt
   ii = (i₀+1):E.count
 
-  # dEdt = I - D - R?
-  total = I[ii] - D[ii] - R[ii]
+  # dEdt = W - D - R?
+  total = W[ii] - D[ii] - R[ii]
   residual = dEdt - total
 
-  plot(E.time[ii], I[ii], label="injection (\$I\$)")
+  plot(E.time[ii], W[ii], label="work (\$W\$)")
   plot(E.time[ii], -D[ii], label="dissipation (\$D\$)")
   plot(E.time[ii], -R[ii], label="drag (\$R\$)")
-  plot(E.time[ii], total, label=L"I-D-R")
+  plot(E.time[ii], total, label=L"W-D-R")
   plot(E.time[ii], dEdt, "k:", label=L"E_t")
   plot(E.time[ii], residual, "c-", label="residual")
 

--- a/examples/twodturb/randomdecay.jl
+++ b/examples/twodturb/randomdecay.jl
@@ -1,7 +1,7 @@
 using PyPlot, FourierFlows
 import FourierFlows.TwoDTurb
 
-   n, L = 256, 2π   # Domain
+   n, L = 256, 2π  # Domain
 nu, nnu = 1e-6, 1  # Viscosity
  dt, nt = 1, 100   # Time step
 

--- a/src/physics/barotropicqg.jl
+++ b/src/physics/barotropicqg.jl
@@ -207,8 +207,8 @@ function calcN_advection!(N, sol, t, s, v, p, g)
   @. v.u = (v.U + v.u)*v.q
   @. v.v = v.v*v.q
 
-  A_mul_B!(v.uh, g.rfftplan, v.u)
-  A_mul_B!(v.vh, g.rfftplan, v.v)
+  A_mul_B!(v.uh, g.rfftplan, v.u) # \hat{(u+U)*q}
+  A_mul_B!(v.vh, g.rfftplan, v.v) # \hat{v*q}
 
   # Nonlinear advection term for q
   @. N = -im*g.kr*v.uh - im*g.l*v.vh

--- a/src/physics/barotropicqg.jl
+++ b/src/physics/barotropicqg.jl
@@ -21,8 +21,8 @@ function Problem(; nx=256, Lx=2π, ny=nx, Ly=Lx, f0 = 1.0, beta=0.0, eta=nothing
 
   # construct params depending whether the problem is forced or not
   if calcFU != nothing || calcFq != nothing # the problem is forced
-    if calcFU==nothing
-      calcFU_fun(t) = 0.0
+    if calcFU == nothing
+      calcFU_fun(t) = nothing
     else
       calcFU_fun = calcFU
     end
@@ -97,7 +97,7 @@ struct ForcedParams{T} <: AbstractParams
   mu::T                      # Linear drag
   nu::T                      # Viscosity coefficient
   nnu::Int                   # Hyperviscous order (nnu=1 is plain old viscosity)
-  calcFU::Function   # Function that calculates the forcing F(t) on
+  calcFU::Function    # Function that calculates the forcing F(t) on
                       # domain-averaged zonal flow U(t)
   calcFq!::Function   # Function that calculates the forcing on QGPV q
 end
@@ -217,14 +217,15 @@ end
 
 function calcN_forced!(N, sol, t, s, v, p, g)
   calcN_advection!(N, sol, t, s, v, p, g)
-
-  # 'Nonlinear' term for U with topographic correlation.
-  # Note: < v*eta > = sum( conj(vh)*eta ) / (nx^2*ny^2) if fft is used
-  # while < v*eta > = 2*sum( conj(vh)*eta ) / (nx^2*ny^2) if rfft is used
-  if size(sol)[1] == g.nkr
-    N[1, 1] = p.calcFU(t) + 2*sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
-  else
-    N[1, 1] = p.calcFU(t) + sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
+  if p.calcFU(t) != nothing
+    # 'Nonlinear' term for U with topographic correlation.
+    # Note: < v*eta > = sum( conj(vh)*eta ) / (nx^2*ny^2) if fft is used
+    # while < v*eta > = 2*sum( conj(vh)*eta ) / (nx^2*ny^2) if rfft is used
+    if size(sol)[1] == g.nkr
+      N[1, 1] = p.calcFU(t) + 2*sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
+    else
+      N[1, 1] = p.calcFU(t) + sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
+    end
   end
   if t == s.t # not a substep
     v.prevsol .= s.sol # used to compute budgets when forcing is stochastic

--- a/src/physics/barotropicqg.jl
+++ b/src/physics/barotropicqg.jl
@@ -2,11 +2,70 @@ module BarotropicQG
 using FourierFlows
 Grid = TwoDGrid
 
-# Params
+"""
+    Problem(; parameters...)
+
+Construct a BarotropicQG turbulence problem.
+"""
+function Problem(; nx=256, Lx=2π, ny=nx, Ly=Lx, f0 = 1.0, beta=0.0, eta=nothing,
+    nu=0.0, nnu=1, mu=0.0, dt=0.01, stepper="RK4", calcFU=nothing, calcFq=nothing)
+
+  # the grid
+  g  = BarotropicQG.Grid(nx, Lx, ny, Ly)
+
+  # topographic PV
+  if eta==nothing
+    eta = 0*g.X
+    etah = rfft(eta)
+  end
+
+  # construct params depending whether the problem is forced or not
+  if calcFU != nothing || calcFq != nothing # the problem is forced
+    if calcFU==nothing
+      calcFU_fun(t) = 0.0
+    else
+      calcFU_fun = calcFU
+    end
+    if calcFq==nothing
+      function calcFq!(Fh, sol, t, s, v, p, g)
+        nothing
+      end
+      calcFq_fun = calcFq!
+    else
+      calcFq_fun = calcFq
+    end
+    if typeof(eta)!=Array{Float64,2} #this is true if eta was passes in Problem as a function
+      pr = BarotropicQG.ForcedParams(g, f0, beta, eta, mu, nu, nnu, calcFU_fun, calcFq_fun)
+    else
+      pr = BarotropicQG.ForcedParams(f0, beta, eta, etah, mu, nu, nnu, calcFU_fun, calcFq_fun)
+    end
+    vs = BarotropicQG.ForcedVars(g)
+    eq = BarotropicQG.Equation(pr, g)
+    ts = FourierFlows.autoconstructtimestepper(stepper, dt, eq.LC, g)
+  else # initial value problem
+    if typeof(eta)!=Array{Float64,2} #this is true if eta was passes in Problem as a function
+      pr = BarotropicQG.Params(g, f0, beta, eta, mu, nu, nnu)
+    else
+      pr = BarotropicQG.Params(f0, beta, eta, etah, mu, nu, nnu)
+    end
+    vs = BarotropicQG.Vars(g)
+    eq = BarotropicQG.Equation(pr, g)
+    ts = FourierFlows.autoconstructtimestepper(stepper, dt, eq.LC, g)
+  end
+  FourierFlows.Problem(g, vs, pr, eq, ts)
+end
+
+InitialValueProblem(; kwargs...) = Problem(; kwargs...)
+ForcedProblem(; kwargs...) = Problem(; kwargs...)
+
+"""
+    Params(g::TwoDGrid, f0, beta, FU, eta, mu, nu, nun)
+
+Returns the params for an unforced two-dimensional barotropic QG problem.
+"""
 struct Params{T} <: AbstractParams
   f0::T                      # Constant planetary vorticity
   beta::T                    # Planetary vorticity y-gradient
-  FU::Function               # Time-dependent forcing of domain average flow
   eta::Array{T,2}            # Topographic PV
   etah::Array{Complex{T},2}  # FFT of Topographic PV
   mu::T                      # Linear drag
@@ -15,21 +74,68 @@ struct Params{T} <: AbstractParams
 end
 
 """
-Constructor that accepts generating function for the topographic height, eta.
+    Params(g::TwoDGrid, f0, beta, eta::Function, mu, nu, nun)
+
+Constructor for Params that accepts a generating function for the topographic PV.
 """
-function Params(g::TwoDGrid, f0, beta, FU, eta, mu, nu, nun)
+function Params(g::TwoDGrid, f0, beta, eta::Function, mu, nu, nun)
   etagrid = eta(g.X, g.Y)
   etah = rfft(etagrid)
-  Params(f0, beta, FU, etagrid, etah, mu, nu, nun)
+  Params(f0, beta, etagrid, etah, mu, nu, nun)
 end
 
-# Equations
-function Equation(p, g)
+"""
+    ForcedParams(g::TwoDGrid, f0, beta, FU, eta, mu, nu, nun)
+
+Returns the params for an forced two-dimensional barotropic QG problem.
+"""
+struct ForcedParams{T} <: AbstractParams
+  f0::T                      # Constant planetary vorticity
+  beta::T                    # Planetary vorticity y-gradient
+  eta::Array{T,2}            # Topographic PV
+  etah::Array{Complex{T},2}  # FFT of Topographic PV
+  mu::T                      # Linear drag
+  nu::T                      # Viscosity coefficient
+  nun::Int                   # Hyperviscous order (nun=1 is plain old viscosity)
+  calcFU::Function   # Function that calculates the forcing F(t) on
+                      # domain-averaged zonal flow U(t)
+  calcFq!::Function   # Function that calculates the forcing on QGPV q
+end
+
+"""
+    ForcedParams(g::TwoDGrid, f0, beta, eta::Function, mu, nu, nun, calcFU, calcFq)
+
+Constructor for Params that accepts a generating function for the topographic PV.
+"""
+function ForcedParams(g::TwoDGrid, f0, beta, eta::Function, mu, nu, nun, calcFU::Function, calcFq::Function)
+  etagrid = eta(g.X, g.Y)
+  etah = rfft(etagrid)
+  ForcedParams(f0, beta, etagrid, etah, mu, nu, nun, calcFU, calcFq)
+end
+
+
+"""
+    Equation(p, g)
+
+Returns the equation for two-dimensional barotropic QG problem with params p and grid g.
+"""
+function Equation(p::Params, g)
   LC = @. -p.mu - p.nu*g.KKrsq^p.nun + im*p.beta*g.kr*g.invKKrsq
-  FourierFlows.Equation(LC, calcN!)
+  LC[1, 1] = 0
+  FourierFlows.Equation{typeof(LC[1, 1]),2}(LC, calcN_advection!)
 end
 
-# Vars
+function Equation(p::ForcedParams, g)
+  LC = @. -p.mu - p.nu*g.KKrsq^p.nun + im*p.beta*g.kr*g.invKKrsq
+  LC[1, 1] = 0
+  FourierFlows.Equation{typeof(LC[1, 1]),2}(LC, calcN_forced!)
+end
+
+"""
+    Vars(g)
+
+Returns the vars for unforced two-dimensional barotropic QG problem with grid g.
+"""
 mutable struct Vars{T} <: AbstractVars
   q::Array{T,2}
   U::T
@@ -52,11 +158,47 @@ function Vars(g::TwoDGrid)
   T = typeof(g.Lx)
   @createarrays T (g.nx, g.ny) q u v uUq vq psi zeta
   @createarrays Complex{T} (g.nkr, g.nl) qh uh vh uUqh vqh psih zetah
- Vars(q, 0.0, u, v, uUq, vq, psi, zeta, qh, uh, vh, uUqh, vqh, psih, zetah)
+  Vars(q, 0.0, u, v, uUq, vq, psi, zeta, qh, uh, vh, uUqh, vqh, psih, zetah)
 end
 
+"""
+    ForcedVars(g)
+
+Returns the vars for forced two-dimensional barotropic QG problem with grid g.
+"""
+mutable struct ForcedVars{T} <: AbstractVars
+  q::Array{T,2}
+  U::T
+  u::Array{T,2}
+  v::Array{T,2}
+  uUq::Array{T,2}
+  vq::Array{T,2}
+  psi::Array{T,2}
+  zeta::Array{T,2}
+  qh::Array{Complex{T},2}
+  uh::Array{Complex{T},2}
+  vh::Array{Complex{T},2}
+  uUqh::Array{Complex{T},2}
+  vqh::Array{Complex{T},2}
+  psih::Array{Complex{T},2}
+  zetah::Array{Complex{T},2}
+  Fqh::Array{Complex{T},2}
+  prevsol::Array{Complex{T},2}
+end
+
+function ForcedVars(g::TwoDGrid)
+  T = typeof(g.Lx)
+  @createarrays T (g.nx, g.ny) q u v uUq vq psi zeta
+  @createarrays Complex{T} (g.nkr, g.nl) qh uh vh uUqh vqh psih zetah Fqh prevsol
+  ForcedVars(q, 0.0, u, v, uUq, vq, psi, zeta, qh, uh, vh, uUqh, vqh, psih, zetah, Fqh, prevsol)
+end
+
+
+# -------
 # Solvers
-function calcN!(N, sol, t, s, v, p, g)
+# -------
+
+function calcN_advection!(N, sol, t, s, v, p, g)
   # Note that U = sol[1, 1]. For all other elements ζ = sol
   v.U = sol[1, 1].re
   @. v.zetah = sol
@@ -78,21 +220,39 @@ function calcN!(N, sol, t, s, v, p, g)
   A_mul_B!(v.uUqh, g.rfftplan, v.uUq)
   A_mul_B!(v.vqh,  g.rfftplan, v.vq)
 
-  # Nonlinear term for q
+  # Nonlinear advection term for q
   @. N = -im*g.kr*v.uUqh - im*g.l*v.vqh
+end
+
+function calcN_forced!(N, sol, t, s, v, p, g)
+  calcN_advection!(N, sol, t, s, v, p, g)
 
   # 'Nonlinear' term for U with topographic correlation.
   # Note: < v*eta > = sum( conj(vh)*eta ) / (nx^2*ny^2) if fft is used
   # while < v*eta > = 2*sum( conj(vh)*eta ) / (nx^2*ny^2) if rfft is used
   if size(sol)[1] == g.nkr
-    N[1, 1] = p.FU(t) + 2*sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
+    N[1, 1] = p.calcFU(t) + 2*sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
   else
-    N[1, 1] = p.FU(t) + sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
+    N[1, 1] = p.calcFU(t) + sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
   end
-
+  if t == s.t # not a substep
+    v.prevsol .= s.sol # used to compute budgets when forcing is stochastic
+    p.calcFq!(v.Fqh, sol, t, s, v, p, g)
+  end
+  @. N += v.Fqh
+  nothing
 end
 
+
+# ----------------
 # Helper functions
+# ----------------
+
+"""
+    updatevars!(v, s, g)
+
+Update the vars in v on the grid g with the solution in s.sol.
+"""
 function updatevars!(s, v, p, g)
   v.U = s.sol[1, 1].re
   @. v.zetah = s.sol
@@ -117,7 +277,13 @@ end
 
 updatevars!(prob) = updatevars!(prob.state, prob.vars, prob.params, prob.grid)
 
+"""
+    set_zeta!(prob, zeta)
+    set_q!(s, v, g, zeta)
 
+Set the solution s.sol as the transform of zeta and update variables v
+on the grid g.
+"""
 function set_zeta!(s, v, p, g, zeta)
   #zeta = similar(v.u)
 
@@ -153,9 +319,9 @@ end
 """
 Returns the domain-averaged enstrophy.
 """
-U00(prob) = s.sol[1, 1]
-energy00(prob) = 0.5*prob.state.sol[1, 1].^2
-enstrophy00(prob) = prob.params.beta*prob.state.sol[1, 1]
+U00(prob) = real(s.sol[1, 1])
+energy00(prob) = real(0.5*prob.state.sol[1, 1].^2)
+enstrophy00(prob) = real(prob.params.beta*prob.state.sol[1, 1])
 
 
 

--- a/src/physics/barotropicqg.jl
+++ b/src/physics/barotropicqg.jl
@@ -221,11 +221,7 @@ function calcN_forced!(N, sol, t, s, v, p, g)
     # 'Nonlinear' term for U with topographic correlation.
     # Note: < v*eta > = sum( conj(vh)*eta ) / (nx^2*ny^2) if fft is used
     # while < v*eta > = 2*sum( conj(vh)*eta ) / (nx^2*ny^2) if rfft is used
-    if size(sol)[1] == g.nkr
-      N[1, 1] = p.calcFU(t) + 2*sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
-    else
-      N[1, 1] = p.calcFU(t) + sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
-    end
+    N[1, 1] = p.calcFU(t) + 2*sum(conj(v.vh).*p.etah).re / (g.nx^2.0*g.ny^2.0)
   end
   if t == s.t # not a substep
     v.prevsol .= s.sol # used to compute budgets when forcing is stochastic

--- a/src/physics/twodturb.jl
+++ b/src/physics/twodturb.jl
@@ -2,7 +2,7 @@ module TwoDTurb
 using FourierFlows, Requires
 
 """
-    InitialValueProblem(; parameters...)
+    Problem(; parameters...)
 
 Construct an 2D turbulence problem.
 """
@@ -91,7 +91,7 @@ end
 """
     ForcedVars(g)
 
-Returns the vars for unforced two-dimensional turbulence with grid g.
+Returns the vars for forced two-dimensional turbulence with grid g.
 """
 function ForcedVars(g)
   @createarrays typeof(g.Lx) (g.nx, g.ny) q U V
@@ -246,7 +246,7 @@ Returns the domain-averaged dissipation rate. nnu must be >= 1.
 end
 
 @inline dissipation(prob::AbstractProblem) = dissipation(prob.state, prob.vars, prob.params, prob.grid)
-  
+
 """
     work(prob)
     work(s, v, p, g)

--- a/test/test_barotropicqg.jl
+++ b/test/test_barotropicqg.jl
@@ -29,7 +29,131 @@ function test_baroQG_RossbyWave(stepper, dt, nsteps, g, p, v, eq)
     isapprox(ζ_theory, v.zeta, rtol=g.nx*g.ny*nsteps*1e-12)
 end
 
+"""
+    test_stochasticforcingbudgets(; kwargs...)
 
+Tests if the energy budgets are closed for BarotropicQG with stochastic forcing.
+"""
+
+function test_stochasticforcingbudgets(; n=256, dt=0.01, L=2π, nu=1e-7, nnu=2, mu=1e-1, message=false)
+  n, L  = 256, 2π
+  nu, nnu = 1e-7, 2
+  mu = 1e-1
+  dt, tf = 0.005, 0.1/mu
+  nt = round(Int, tf/dt)
+  ns = 1
+
+  # Forcing
+  kf, dkf = 12.0, 2.0
+  σ = 0.1
+  gr  = TwoDGrid(n, L)
+
+  force2k = exp.(-(sqrt.(gr.KKrsq)-kf).^2/(2*dkf^2))
+  force2k[gr.KKrsq .< 2.0^2 ] = 0
+  force2k[gr.KKrsq .> 20.0^2 ] = 0
+  force2k[gr.Kr.<2π/L] = 0
+  σ0 = FourierFlows.parsevalsum(force2k.*gr.invKKrsq/2.0, gr)/(gr.Lx*gr.Ly)
+  force2k .= σ/σ0 * force2k
+
+  srand(1234)
+
+  function calcFq!(F, sol, t, s, v, p, g)
+    eta = exp.(2π*im*rand(size(sol)))/sqrt(s.dt)
+    eta[1, 1] = 0
+    @. F = eta .* sqrt(force2k)
+    nothing
+  end
+
+  prob = BarotropicQG.ForcedProblem(nx=n, Lx=L, nu=nu, nnu=nnu, mu=mu, dt=dt,
+   stepper="RK4", calcFq=calcFq!)
+
+  s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts;
+
+  BarotropicQG.set_zeta!(prob, 0*g.X)
+  E = Diagnostic(FourierFlows.BarotropicQG.energy,      prob, nsteps=nt)
+  D = Diagnostic(FourierFlows.BarotropicQG.dissipation, prob, nsteps=nt)
+  R = Diagnostic(FourierFlows.BarotropicQG.drag,        prob, nsteps=nt)
+  W = Diagnostic(FourierFlows.BarotropicQG.work,        prob, nsteps=nt)
+  diags = [E, D, W, R]
+
+  # Step forward
+
+  stepforward!(prob, diags, round(Int, nt))
+
+  BarotropicQG.updatevars!(prob)
+
+  cfl = prob.ts.dt*maximum([maximum(v.v)/g.dx, maximum(v.u)/g.dy])
+
+  E, D, W, R = diags
+
+  t = round(mu*prob.state.t, 2)
+
+  i₀ = 1
+  dEdt = (E[(i₀+1):E.count] - E[i₀:E.count-1])/prob.ts.dt
+  ii = (i₀):E.count-1
+  ii2 = (i₀+1):E.count
+
+  # dEdt = W - D - R?
+  # If the Ito interpretation was used for the work
+  # then we need to add the drift term
+  # total = W[ii2]+σ - D[ii] - R[ii]      # Ito
+  total = W[ii2] - D[ii] - R[ii]        # Stratonovich
+
+  residual = dEdt - total
+
+  if message
+    @printf("step: %04d, t: %.1f, cfl: %.3f, time: %.2f s\n", prob.step, prob.t, cfl, tc)
+  end
+  # println(mean(abs.(residual)))
+  isapprox(mean(abs.(residual)), 0, atol=1e-4)
+end
+
+"""
+    testnonlinearterms(dt, stepper; kwargs...)
+
+Tests the advection term in the twodturb module by timestepping a
+test problem with timestep dt and timestepper identified by the string stepper.
+The test problem is derived by picking a solution ζf (with associated
+streamfunction ψf) for which the advection term J(ψf, ζf) is non-zero. Next, a
+forcing Ff is derived according to Ff = ∂ζf/∂t + J(ψf, ζf) - nuΔζf. One solution
+to the vorticity equation forced by this Ff is then ζf. (This solution may not
+be realized, at least at long times, if it is unstable.)
+"""
+function testnonlinearterms(dt, stepper; n=128, L=2π, nu=1e-2, nnu=1, mu=0.0, message=false)
+  n, L  = 128, 2π
+  nu, nnu = 1e-2, 1
+  mu = 0.0
+  tf = 1.0
+  nt = round(Int, tf/dt)
+
+  gr  = TwoDGrid(n, L)
+  x, y = gr.X, gr.Y
+
+  psif = @. sin(2x)*cos(2y) + 2sin(x)*cos(3y)
+  qf = @. -8sin(2x)*cos(2y) - 20sin(x)*cos(3y)
+
+  Ff = @. -(
+    nu*( 64sin(2x)*cos(2y) + 200sin(x)*cos(3y) )
+    + 8*( cos(x)*cos(3y)*sin(2x)*sin(2y) - 3cos(2x)*cos(2y)*sin(x)*sin(3y) )
+  )
+
+  Ffh = rfft(Ff)
+
+  # Forcing
+  function calcFq!(Fqh, sol, t, s, v, p, g)
+    Fqh .= Ffh
+    nothing
+  end
+
+  prob = BarotropicQG.ForcedProblem(nx=n, Lx=L, nu=nu, nnu=nnu, mu=mu, dt=dt, stepper=stepper, calcFq=calcFq!)
+  s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts
+  BarotropicQG.set_zeta!(prob, qf)
+
+  # Step forward
+  stepforward!(prob, round(Int, nt))
+  BarotropicQG.updatevars!(prob)
+  isapprox(v.q, qf, rtol=1e-13)
+end
 
 # -----------------------------------------------------------------------------
 # Running the tests
@@ -70,6 +194,10 @@ dt, nsteps  = 1e-3, 200
 
 dt, nsteps  = 1e-4, 2000
 @test test_baroQG_RossbyWave("ForwardEuler", dt, nsteps, g, p, v, eq)
-#
+
 dt, nsteps  = 1e-4, 2000
 @test test_baroQG_RossbyWave("FilteredForwardEuler", dt, nsteps, g, p, v, eq)
+
+@test test_stochasticforcingbudgets()
+
+@test testnonlinearterms(0.0005, "ForwardEuler")

--- a/test/test_barotropicqg.jl
+++ b/test/test_barotropicqg.jl
@@ -44,10 +44,9 @@ Lx = 2π
  μ = 0.0
 
 η(x,y) = zeros(nx, nx)
-FU(t)  = 0
 
 g  = BarotropicQG.Grid(nx, Lx)
-p  = BarotropicQG.Params(g, f0, β, FU, η, μ, ν, νn)
+p  = BarotropicQG.Params(g, f0, β, η, μ, ν, νn)
 v  = BarotropicQG.Vars(g)
 eq = BarotropicQG.Equation(p, g)
 

--- a/test/test_twodturb.jl
+++ b/test/test_twodturb.jl
@@ -1,5 +1,4 @@
 import FourierFlows.TwoDTurb
-import FourierFlows.TwoDTurb: energy, enstrophy, dissipation, work, drag
 
 cfl(prob) = maximum([maximum(abs.(prob.vars.U)), maximum(abs.(prob.vars.V))]*prob.ts.dt/prob.grid.dx)
 
@@ -61,10 +60,10 @@ function stochasticforcingbudgetstest(; n=256, dt=0.01, L=2π, nu=1e-7, nnu=2, m
   s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts;
 
   TwoDTurb.set_q!(prob, 0*g.X)
-  E = Diagnostic(energy,      prob, nsteps=nt)
-  D = Diagnostic(dissipation, prob, nsteps=nt)
-  R = Diagnostic(drag,        prob, nsteps=nt)
-  W = Diagnostic(work,        prob, nsteps=nt)
+  E = Diagnostic(FourierFlows.TwoDTurb.energy,      prob, nsteps=nt)
+  D = Diagnostic(FourierFlows.TwoDTurb.dissipation, prob, nsteps=nt)
+  R = Diagnostic(FourierFlows.TwoDTurb.drag,        prob, nsteps=nt)
+  W = Diagnostic(FourierFlows.TwoDTurb.work,        prob, nsteps=nt)
   diags = [E, D, W, R]
 
   # Step forward


### PR DESCRIPTION
- adds forcing in QGPV (with `calcFq` function) and forcing in domain-averaged zonal flow U(t) (with `calcFU` function)
- adds problem constructor (initial value problem + force problem)
- adds a `forcedbetaturb.jl` example
- updates the `decayingbetaturb.jl` and `ACConelayer.jl` examples to use the simpler `Problem()` function