### PR TITLE
Increase test Coverage

### DIFF
--- a/src/physics/twodturb.jl
+++ b/src/physics/twodturb.jl
@@ -225,12 +225,6 @@ solution `s.sol`.
 """
 @inline enstrophy(s, g) = 1/(2*g.Lx*g.Ly)*FourierFlows.parsevalsum2(s.sol, g)
 
-"""
-    enstrophy(prob)
-
-Returns the domain-averaged enstrophy in the Fourier-transformed vorticity
-solution `prob.state.sol`.
-"""
 @inline enstrophy(prob) = enstrophy(prob.state, prob.grid)
 
 """

--- a/test/test_barotropicqg.jl
+++ b/test/test_barotropicqg.jl
@@ -15,6 +15,8 @@ function test_baroQG_RossbyWave(stepper, dt, nsteps)
     mu = 0.0
     nu = 0.0
 
+  # the following if statement is called so that all the cases of
+  # Problem() fuction are tested
   if stepper=="ForwardEuler"
     eta = zeros(nx, nx)
   else

--- a/test/test_kuramotosivashinsky.jl
+++ b/test/test_kuramotosivashinsky.jl
@@ -1,19 +1,19 @@
-using FourierFlows, FourierFlows.KuramotoSivashinsky
+import FourierFlows.KuramotoSivashinsky
 
 function growingwavetest()
   nx, Lx = 256, 4π
   dt, nt = 1e-6, 100
-  prob = InitialValueProblem(nx=nx, Lx=Lx, dt=dt, stepper="FilteredETDRK4")
+  prob = KuramotoSivashinsky.InitialValueProblem(nx=nx, Lx=Lx, dt=dt, stepper="FilteredETDRK4")
   x = prob.grid.x
 
   # Initial condition
   a = 1e-4
   u0 = @. a*cos(x/2)
   ua(x, t) = a*exp(3t/16)*cos(x/2) + a^2*2/3*(exp(3t/8)-1)*sin(x)
-  set_u!(prob, u0)
+  KuramotoSivashinsky.set_u!(prob, u0)
 
   stepforward!(prob, nt)
-  updatevars!(prob)
+  KuramotoSivashinsky.updatevars!(prob)
   u, t = prob.vars.u, prob.t
 
   arbitraryerror = 1e-14 # what is an appropriate error?


### PR DESCRIPTION
- fixes bug in `BarotropicQG.enstrophy()`: when U(t) was present enstrophy was including `sol[1, 1]^2`.