### PR TITLE
Towards Julia v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ os:
 
 julia:
   - 0.7
-  # - nightly
+  - 1.0
+  - nightly
 
 matrix:
   allow_failures:
+    - julia: 1.0
     - julia: nightly
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,14 @@ before_script:
  - julia -e 'using Pkg; Pkg.add("Interpolations"); Pkg.add("Requires");'
  - julia -e 'using Pkg; Pkg.add("FFTW");'
 
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  # - julia -e 'using Pkg; Pkg.clone(pwd())'
-  - julia -e 'using Pkg; Pkg.test("FourierFlows", coverage=true)'
+# script:
+#   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#   - julia -e 'using Pkg; Pkg.test("FourierFlows", coverage=true)'
 
 after_success:
   - julia -e 'using Pkg; Pkg.add("Documenter")'
-  - julia -e 'using Pkg; cd(Pkg.dir("FourierFlows")); include(joinpath("docs", "make.jl"))'
-  - julia -e 'using Pkg; cd(Pkg.dir("FourierFlows")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-  - julia -e 'using Pkg; cd(Pkg.dir("FourierFlows")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Documenter"); Pkg.dir("FourierFlows"); include(joinpath("docs", "make.jl"))'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); Pkg.dir("FourierFlows"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,30 +5,28 @@ os:
   - linux
 
 julia:
+  - 0.7
   # - nightly
-  - 0.6.3
+
+matrix:
+  allow_failures:
+    - julia: nightly
 
 before_script:
- - julia -e 'Pkg.add("JLD2"); Pkg.add("SpecialFunctions"); Pkg.add("CuArrays");'
- - julia -e 'Pkg.add("Interpolations"); Pkg.add("Requires");'
- # - julia -e 'ENV["PYTHON"]=""; Pkg.build("PyCall"); using PyPlot;'
-
-# this was the old way of running tests before runtests.jl
-# script:
-#   - julia test/test_grid.jl
-#   - julia test/test_twodturb.jl
-#   - julia test/test_utils.jl
+ - julia -e 'using Pkg; Pkg.add("JLD2"); Pkg.add("SpecialFunctions"); Pkg.add("CuArrays");'
+ - julia -e 'using Pkg; Pkg.add("Interpolations"); Pkg.add("Requires");'
+ - julia -e 'using Pkg; Pkg.add("FFTW");'
 
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'Pkg.clone(pwd())'
-  - julia -e 'Pkg.test("FourierFlows",coverage=true)'
+  # - julia -e 'using Pkg; Pkg.clone(pwd())'
+  - julia -e 'using Pkg; Pkg.test("FourierFlows", coverage=true)'
 
 after_success:
-  - julia -e 'Pkg.add("Documenter")'
-  - julia -e 'cd(Pkg.dir("FourierFlows")); include(joinpath("docs", "make.jl"))'
-  - julia -e 'cd(Pkg.dir("FourierFlows")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-  - julia -e 'cd(Pkg.dir("FourierFlows")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Documenter")'
+  - julia -e 'using Pkg; cd(Pkg.dir("FourierFlows")); include(joinpath("docs", "make.jl"))'
+  - julia -e 'using Pkg; cd(Pkg.dir("FourierFlows")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; cd(Pkg.dir("FourierFlows")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
 
 notifications:
   email: true

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,353 @@
+[[AbstractFFTs]]
+deps = ["Compat", "LinearAlgebra"]
+git-tree-sha1 = "8d59c3b1463b5e0ad05a3698167f85fac90e184d"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "0.3.2"
+
+[[Adapt]]
+git-tree-sha1 = "182b4f3518a049cd3b67e25102c99b530afeda82"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "0.2.0"
+
+[[AxisAlgorithms]]
+deps = ["Compat", "WoodburyMatrices"]
+git-tree-sha1 = "99dabbe853e4f641ab21a676131f2cf9fb29937e"
+uuid = "13072b0f-2c55-5437-9ae7-d433b7a33950"
+version = "0.3.0"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinDeps]]
+deps = ["Compat", "Libdl", "SHA", "URIParser"]
+git-tree-sha1 = "a6e1f6b5818ef909cda3a7011dd97c3dac6dc369"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "0.8.9"
+
+[[BinaryProvider]]
+deps = ["Libdl", "Pkg", "SHA", "Test"]
+git-tree-sha1 = "2883bc1b389e3d57a134796c39c788db3f298cef"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.4.0"
+
+[[CUDAapi]]
+deps = ["InteractiveUtils", "Libdl", "Logging", "Pkg", "Test"]
+git-tree-sha1 = "576625a0922ab766ff5d7f685c6907d28dccf52f"
+uuid = "3895d2a7-ec45-59b8-82bb-cfc6a382f9b3"
+version = "0.5.0"
+
+[[CUDAdrv]]
+deps = ["CUDAapi", "InteractiveUtils", "Libdl", "Pkg", "Printf", "Test"]
+git-tree-sha1 = "0bbb47620dfda5b90dfc1820f6b44dfd71ad875c"
+uuid = "c5f51814-7f29-56b8-a69c-e4d8f6be1fde"
+version = "0.8.5"
+
+[[CUDAnative]]
+deps = ["CUDAapi", "CUDAdrv", "InteractiveUtils", "LLVM", "Libdl", "Logging", "Pkg", "Printf", "Statistics", "Test"]
+git-tree-sha1 = "c73ff62a410775627ed36d7b400c9dbae7ff65a2"
+uuid = "be33ccc6-a3ff-5ff2-a52e-74243cff1e17"
+version = "0.8.6"
+
+[[CodecZlib]]
+deps = ["BinaryProvider", "Compat", "Test", "TranscodingStreams"]
+git-tree-sha1 = "82742ef572290f566c6fc6d977d87586a0d3d5f1"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.4.3"
+
+[[CommonSubexpressions]]
+deps = ["Test"]
+git-tree-sha1 = "efdaf19ab11c7889334ca247ff4c9f7c322817b0"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+version = "0.2.0"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "277d3807440d9793421354b6680911fc95d91a84"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "1.0.1"
+
+[[ComputationalResources]]
+git-tree-sha1 = "9f1aaccaaa3658ca0665870c48a3b3e7374dab5b"
+uuid = "ed09eef8-17a6-5b46-8889-db040fac31e3"
+version = "0.2.0"
+
+[[Conda]]
+deps = ["Compat", "JSON", "VersionParsing"]
+git-tree-sha1 = "b76a441539d66a18ba34df28d34dc5b9202164a3"
+uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+version = "1.0.0"
+
+[[Coverage]]
+deps = ["Compat", "HTTP", "JSON", "MbedTLS"]
+git-tree-sha1 = "cf60c0f9832b897d22a65be674148a7f37b40f6a"
+uuid = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
+version = "0.6.0"
+
+[[CuArrays]]
+deps = ["AbstractFFTs", "Adapt", "CUDAapi", "CUDAdrv", "CUDAnative", "ForwardDiff", "GPUArrays", "MacroTools", "NNlib"]
+git-tree-sha1 = "c5a784ea21087312a20f9b7ab581bff6e39e7f59"
+uuid = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
+version = "0.6.2"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "REPL", "Random", "Serialization", "Test"]
+git-tree-sha1 = "6e72a9098f5774601c8c8d6a4511a68270594910"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.11.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[DiffResults]]
+deps = ["Compat", "StaticArrays"]
+git-tree-sha1 = "db8acf46717b13d6c48deb7a12007c7f85a70cf7"
+uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+version = "0.0.3"
+
+[[DiffRules]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "c49ec69428ffea0c1d1bbdc63d1a70f5df5860ad"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "0.0.7"
+
+[[Distributed]]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[DocStringExtensions]]
+deps = ["Compat"]
+git-tree-sha1 = "0d767d338c201b1b2064e2186a0b63ac1e55dbb1"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.4.5"
+
+[[Documenter]]
+deps = ["Compat", "DocStringExtensions", "Logging", "REPL"]
+git-tree-sha1 = "ef29b036c7eb40bca1ac5471639ec01e98717d27"
+uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+version = "0.19.3"
+
+[[FFTW]]
+deps = ["AbstractFFTs", "BinaryProvider", "Compat", "Conda", "Libdl", "LinearAlgebra", "Reexport", "Test"]
+git-tree-sha1 = "60346335ad3aa60bfbdc358c6d1468bffbcff071"
+uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+version = "0.2.3"
+
+[[FileIO]]
+deps = ["Pkg", "Random", "Test"]
+git-tree-sha1 = "b80161b7e679a1241f9441ebfa60b62d4239cf99"
+uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+version = "1.0.1"
+
+[[ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "InteractiveUtils", "LinearAlgebra", "NaNMath", "Pkg", "Random", "SparseArrays", "SpecialFunctions", "StaticArrays", "Test"]
+git-tree-sha1 = "34abc9c9650a3a661b7c2cbc685825d5e58bf074"
+uuid = "f6369f11-7733-5829-9624-2563aa707210"
+version = "0.8.4"
+
+[[GPUArrays]]
+deps = ["StaticArrays"]
+git-tree-sha1 = "57b0aea0a033b96efe91d7d614d172f43f798179"
+uuid = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+version = "0.2.4"
+
+[[HTTP]]
+deps = ["Base64", "Dates", "Distributed", "IniFile", "MbedTLS", "Sockets", "Test"]
+git-tree-sha1 = "8a0f75e8b09df01d9f1ba9ad3fbf8b4983595d20"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.6.14"
+
+[[IniFile]]
+deps = ["Test"]
+git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
+uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
+version = "0.5.0"
+
+[[InteractiveUtils]]
+deps = ["LinearAlgebra", "Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[Interpolations]]
+deps = ["AxisAlgorithms", "Compat", "LinearAlgebra", "OffsetArrays", "Ratios", "ShowItLikeYouBuildIt", "WoodburyMatrices"]
+git-tree-sha1 = "da2709d9f94b0ebd3da2c7cb92a1ce1e0d807913"
+uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+version = "0.8.0"
+
+[[JLD2]]
+deps = ["CodecZlib", "Compat", "DataStructures", "FileIO"]
+git-tree-sha1 = "64d3ffd85e557a9e4afa9f256c1944ae7672bc80"
+uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+version = "0.0.6"
+
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Pkg", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "fec8e4d433072731466d37ed0061b3ba7f70eeb9"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.19.0"
+
+[[LLVM]]
+deps = ["InteractiveUtils", "Pkg", "Printf", "Test", "Unicode"]
+git-tree-sha1 = "8e6a68cd28c750d71a10ac1b232c341d01eab801"
+uuid = "929cbde3-209d-540e-8aea-75f648917ca0"
+version = "0.9.13"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MacroTools]]
+deps = ["Compat"]
+git-tree-sha1 = "c443e1c8d58a4e9f61b708ad0a88286c7042145b"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.4.4"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS]]
+deps = ["BinaryProvider", "Compat", "Pkg", "Sockets"]
+git-tree-sha1 = "17d5a81dbb1e682d4ff707c01f0afe5948068fa6"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "0.6.0"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[NNlib]]
+deps = ["Libdl", "LinearAlgebra", "MacroTools", "Requires", "Test"]
+git-tree-sha1 = "83dd97789dcd7718ae4f62ac7104e575894b7368"
+uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+version = "0.4.0"
+
+[[NaNMath]]
+deps = ["Compat"]
+git-tree-sha1 = "ce3b85e484a5d4c71dd5316215069311135fa9f2"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "0.3.2"
+
+[[OffsetArrays]]
+deps = ["DelimitedFiles", "Test"]
+git-tree-sha1 = "f8cd140824f74f2948ff8660bc2292e16d29c1b7"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "0.8.1"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Ratios]]
+deps = ["Compat"]
+git-tree-sha1 = "fd159bead0a24e6270fd0573a340312bd4645cc2"
+uuid = "c84ed2f1-dad5-54f0-aa8e-dbefe2724439"
+version = "0.3.0"
+
+[[Reexport]]
+deps = ["Pkg"]
+git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "0.2.0"
+
+[[Requires]]
+deps = ["Test"]
+git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "0.5.2"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[ShowItLikeYouBuildIt]]
+git-tree-sha1 = "e562bce4b0df3ed65562ce2ec7f56cb399368daf"
+uuid = "9966252f-7483-59e3-9a4c-8607a6b2a5fe"
+version = "0.2.0"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SpecialFunctions]]
+deps = ["BinDeps", "BinaryProvider", "Compat", "Libdl"]
+git-tree-sha1 = "d12f8917be3782f4b800ba16003b8d0d4858c2e5"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "0.7.0"
+
+[[StaticArrays]]
+deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
+git-tree-sha1 = "d432c79bef174a830304f8601427a4357dfdbfb7"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "0.8.3"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TranscodingStreams]]
+deps = ["Compat", "Pkg", "Random", "Test"]
+git-tree-sha1 = "9ace282f45e71d2fd3fcb752ca337452560f3108"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.5.4"
+
+[[URIParser]]
+deps = ["Test", "Unicode"]
+git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.0"
+
+[[UUIDs]]
+deps = ["Random"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[VersionParsing]]
+deps = ["Compat"]
+git-tree-sha1 = "e8524bb636735227fd9d750dfa81f98db8bc5b0c"
+uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
+version = "1.1.1"
+
+[[WoodburyMatrices]]
+deps = ["LinearAlgebra", "Random", "SparseArrays", "Test"]
+git-tree-sha1 = "742748a6eec707d55c818747a37ed528688b3ad3"
+uuid = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
+version = "0.4.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,25 @@
+name = "FourierFlows"
+uuid = "2aec4490-903f-5c70-9b11-9bed06a700e1"
+keywords = ["julia", "PDE", "partial differential equations", "spectral methods", "geophysical fluid dynamics"]
+license = "MIT"
+authors = ["Gregory L. Wagner <wagner.greg@gmail.com>", "Navid C. Constantinou <navidcy@gmail.com>"]
+description = "Solvers for partial differential equations on periodic domains using Fourier-based pseudospectral methods."
+documentation = "https://fourierflows.github.io/FourierFlows.jl/latest/"
+repository = "https://github.com/FourierFlows/FourierFlows.jl"
+version = "0.1.3+"
+versions = ["0.0.1", "0.0.2", "0.1.0", "0.1.1", "0.1.2", "0.1.3"]
+
+[deps]
+ComputationalResources = "ed09eef8-17a6-5b46-8889-db040fac31e3"
+Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
+CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ For more details refer to the [documentation](https://fourierflows.github.io/Fou
 
 ## Installation
 
-The package is registered in `METADATA.jl` and can be installed with `Pkg.add`.
+The is a registered package and can be installed by:
 
 ```julia
+julia> using Pkg
 julia> Pkg.add("FourierFlows")
 ```
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,7 @@
-julia 0.6
+julia 0.7
+FFTW 0.2.3
 JLD2 0.0.4
 SpecialFunctions 0.3.6
-Interpolations 0.7.3
-Requires
+Interpolations 0.8
+Requires 0.5.2
+ComputationalResources 0.2.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   # - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
   # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,18 @@
 environment:
   matrix:
-  # - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
 
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+platform:
+  # - x86 # 32-bit
+  - x64 # 64-bit
+
+# Uncomment the following lines to allow failures on nightly julia
+# (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - julia_version: nightly
 
 branches:
   only:
@@ -25,24 +27,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo(); using Pkg;
-      Pkg.clone(pwd(), \"FourierFlows\"); Pkg.build(\"FourierFlows\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "using Pkg; Pkg.test(\"FourierFlows\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ environment:
 branches:
   only:
     - master
+    - TowardsJulia1.0
     - /release-.*/
 
 notifications:
@@ -40,8 +41,8 @@ install:
 build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
+  - C:\projects\julia\bin\julia -e "versioninfo(); using Pkg;
       Pkg.clone(pwd(), \"FourierFlows\"); Pkg.build(\"FourierFlows\")"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"FourierFlows\")"
+  - C:\projects\julia\bin\julia --check-bounds=yes -e "using Pkg; Pkg.test(\"FourierFlows\")"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,7 +27,7 @@ makedocs(
 deploydocs(
        repo = "github.com/FourierFlows/FourierFlows.jl.git",
      target = "build",
-      julia = "0.6.3",
+      julia = "0.7",
      osname = "linux",
        deps = nothing,
        make = nothing

--- a/examples/barotropicqg/ACConelayer.jl
+++ b/examples/barotropicqg/ACConelayer.jl
@@ -1,6 +1,6 @@
 using FourierFlows, PyPlot, JLD2
 
-
+import Printf.@sprintf
 import FourierFlows.BarotropicQG
 import FourierFlows.BarotropicQG: energy, energy00, enstrophy, enstrophy00
 
@@ -38,8 +38,8 @@ s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, pr
 # Files
 filepath = "."
 plotpath = "./plots"
-plotname = "testplots"
-filename = joinpath(filepath, "testdata.jld2")
+plotname = "snapshot"
+filename = joinpath(filepath, "ACConelayer.jld2")
 
 # File management
 if isfile(filename); rm(filename); end

--- a/examples/kuramotosivashinsky/unstableexample.jl
+++ b/examples/kuramotosivashinsky/unstableexample.jl
@@ -7,7 +7,7 @@ x = prob.grid.x
 
 a = 1e-4 # amplitude of initial condition
 u0 = @. a*cos(x/2) # initial condition
-set_u!(prob, u0) 
+set_u!(prob, u0)
 
 ua(x, t) = a*exp(3t/16)*cos(x/2) + a^2*2/3*(exp(3t/8)-1)*sin(x) # analytical solution
 
@@ -23,7 +23,7 @@ for i = 1:nt
   U[:, i] .= prob.vars.u
 end
 
-L1(u) = prob.grid.dx*squeeze(sum(abs.(u), 1), 1)/Lx
+L1(u) = prob.grid.dx*dropdims(sum(abs.(u), dims=1), dims=1)/Lx
 L1(u::Array{T,1}) where {T} = prob.grid.dx*sum(abs.(u))/Lx
 
 close("all")

--- a/examples/traceradvdiff/cellularflow.jl
+++ b/examples/traceradvdiff/cellularflow.jl
@@ -1,54 +1,50 @@
-using FourierFlows, PyPlot, JLD2
-
+using FourierFlows, PyPlot
 import FourierFlows.TracerAdvDiff
 
 # Numerical parameters and time-stepping parameters
 nx  = 128         # 2D resolution = nx^2
 stepper = "RK4"   # timestepper
 dt  = 0.02        # timestep
-nsubs  = 200      # number of time-steps for plotting
+nsubs = 200       # number of time-steps for plotting
 nsteps = 4nsubs   # total number of time-steps (must be multiple of nsubs)
 
 # Physical parameters
-Lx  = 2π      # domain size
+Lx = 2π       # domain size
 kap = 0.002   # diffusivity
 
-gr = TwoDGrid(nx, Lx)
-X, Y = gr.X, gr.Y
-
-# streamfunction (for plotting) and (u,v) flow field
-psiampl = 0.2
+# Flow field
+Psi = 0.2
 m, n = 1, 1
-psiin = @. psiampl * cos(m*X) * cos(n*Y)
-uvel(x, y) = +psiampl * n * cos(m*x) * sin(n*y)
-vvel(x, y) = -psiampl * m * sin(m*x) * cos(n*y)
-
-prob = TracerAdvDiff.ConstDiffProblem(; steadyflow=true,
-    nx=nx, Lx=Lx, kap=kap, u=uvel, v=vvel, dt=dt, stepper=stepper)
-
-s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, prob.ts;
+uvel(x, y) = +Psi * n * cos(m*x) * sin(n*y)
+vvel(x, y) = -Psi * m * sin(m*x) * cos(n*y)
 
 # Initial condition c0 = c(x, y, t=0)
-amplc0, sigc0 = 0.1, 0.1
+C, dc = 0.1, 0.1
 x0, y0 = 1.2, 0
-c0func(x, y) = amplc0*exp(-(x^2+y^2)/(2sigc0^2))
-c0 = c0func.(g.X .- x0, g.Y .- y0)
+c0(x, y) = C*exp( -((x-x0)^2+(y-y0)^2) / (2dc^2))
 
+# Generate problem
+prob = TracerAdvDiff.ConstDiffProblem(nx=nx, Lx=Lx, kap=kap, u=uvel, v=vvel,
+                                      dt=dt, stepper=stepper, steadyflow=true) 
 TracerAdvDiff.set_c!(prob, c0)
 
-"Plot the concentration field and the (u, v) streamlines."
-function plotoutput(prob, fig, axs; drawcolorbar=false)
-  s, v, p, g = prob.state, prob.vars, prob.params, prob.grid
-  t = round(prob.state.t, digits=2)
+# Calculate streamfunction of flow field for plotting
+X, Y = prob.grid.X, prob.grid.Y
+psi = @. Psi * cos(m*X) * cos(n*Y)
+
+"Plot the flow streamlines and tracer concentration."
+function plotoutput(prob, ax; drawcolorbar=false)
 
   TracerAdvDiff.updatevars!(prob)
+  t = round(prob.state.t, digits=2)
 
+  sca(ax)
   cla()
-  pcolormesh(g.X, g.Y, v.c)
+  pcolormesh(X, Y, prob.vars.c)
 
   if drawcolorbar; colorbar(); end
 
-  contour(g.X, g.Y, psiin, 15, colors="k", linewidths=0.7)
+  contour(X, Y, psi, 15, colors="k", linewidths=0.7)
   axis("equal")
   axis("square")
   title("shading: \$c(x, y, t= $t )\$, contours: \$\\psi(x, y)\$")
@@ -58,10 +54,11 @@ function plotoutput(prob, fig, axs; drawcolorbar=false)
   nothing
 end
 
-fig, axs = subplots(ncols=1, nrows=1, figsize=(8, 8))
-plotoutput(prob, fig, axs; drawcolorbar=true)
+fig, ax = subplots(ncols=1, nrows=1, figsize=(8, 8))
+plotoutput(prob, ax; drawcolorbar=true)
 
+# Step problem forward
 while prob.step < nsteps
   stepforward!(prob, nsubs)
-  plotoutput(prob, fig, axs)
+  plotoutput(prob, ax)
 end

--- a/examples/traceradvdiff/cellularflow.jl
+++ b/examples/traceradvdiff/cellularflow.jl
@@ -30,15 +30,16 @@ s, v, p, g, eq, ts = prob.state, prob.vars, prob.params, prob.grid, prob.eqn, pr
 
 # Initial condition c0 = c(x, y, t=0)
 amplc0, sigc0 = 0.1, 0.1
+x0, y0 = 1.2, 0
 c0func(x, y) = amplc0*exp(-(x^2+y^2)/(2sigc0^2))
-c0 = c0func.(g.X-1.2, g.Y)
+c0 = c0func.(g.X .- x0, g.Y .- y0)
 
 TracerAdvDiff.set_c!(prob, c0)
 
 "Plot the concentration field and the (u, v) streamlines."
 function plotoutput(prob, fig, axs; drawcolorbar=false)
   s, v, p, g = prob.state, prob.vars, prob.params, prob.grid
-  t = round(prob.state.t, 2)
+  t = round(prob.state.t, digits=2)
 
   TracerAdvDiff.updatevars!(prob)
 

--- a/examples/twodturb/McWilliams1984.jl
+++ b/examples/twodturb/McWilliams1984.jl
@@ -1,4 +1,4 @@
-using FourierFlows, PyPlot, JLD2
+using FourierFlows, Printf, PyPlot, JLD2, Random
 
 import FourierFlows.TwoDTurb
 import FourierFlows.TwoDTurb: energy, enstrophy
@@ -16,7 +16,7 @@ nsubs = 200
 filepath = "."
 plotpath = "./plots"
 plotname = "testplots"
-filename = joinpath(filepath, "testdata.jld2")
+filename = joinpath(filepath, "McWilliams84.jld2")
 
 # File management
 if isfile(filename); rm(filename); end
@@ -28,7 +28,7 @@ g = prob.grid
 
 # Initial condition closely following pyqg barotropic example
 # that reproduces the results of the paper by McWilliams (1984)
-srand(1234)
+Random.seed!(1234)
 k0, E0 = 6, 0.5
 qi = FourierFlows.peakedisotropicspectrum(g, k0, E0, mask = prob.ts.filter)
 TwoDTurb.set_q!(prob, qi)
@@ -89,5 +89,5 @@ end
 
 plot_output(prob, fig, axs; drawcolorbar=true)
 
-savename = @sprintf("%s_%09d.png", joinpath(plotpath, plotname), prob.step)
+savename = ("%s_%09d.png", joinpath(plotpath, plotname), prob.step)
 savefig(savename, dpi=240)

--- a/examples/twodturb/constantforcing.jl
+++ b/examples/twodturb/constantforcing.jl
@@ -1,4 +1,6 @@
-using PyPlot, FourierFlows
+using PyPlot, FourierFlows, Statistics
+import Printf.@printf
+import Statistics.mean
 import FourierFlows.TwoDTurb
 import FourierFlows.TwoDTurb: energy, dissipation, work, drag
 
@@ -36,9 +38,8 @@ function runtest(prob, nt)
   W = Diagnostic(work,   prob, nsteps=nt)
   diags = [E, D, W, R]
 
-  tic()
-  stepforward!(prob, diags, round(Int, nt))
-  @printf("step: %04d, t: %.1f, time: %.2f s\n", prob.step, prob.t, toq())
+  time = @elapsed stepforward!(prob, diags, round(Int, nt))
+  println("step: %04d, t: %.1f, time: %.2f s\n", prob.step, prob.t, time)
 
   diags
 end

--- a/examples/twodturb/randomdecay.jl
+++ b/examples/twodturb/randomdecay.jl
@@ -1,4 +1,4 @@
-using PyPlot, FourierFlows
+using PyPlot, FourierFlows, FFTW, Printf
 import FourierFlows.TwoDTurb
 
    n, L = 256, 2π  # Domain
@@ -9,14 +9,17 @@ prob = TwoDTurb.Problem(nx=n, Lx=L, nu=nu, nnu=nnu, dt=dt, stepper="FilteredRK4"
 TwoDTurb.set_q!(prob, rand(n, n))
 
 # Step forward
-fig = figure(); tic()
+fig = figure()
+
 for i = 1:10
+  time = @elapsed begin
   stepforward!(prob, nt)
   TwoDTurb.updatevars!(prob)
 
   cfl = maximum(prob.vars.U)*prob.grid.dx/prob.ts.dt
   @printf("step: %04d, t: %6.1f, cfl: %.2f, ", prob.step, prob.t, cfl)
-  toc(); tic()
+  end
+  println("time: ", time)
 
   clf(); imshow(prob.vars.q); pause(0.01)
 end

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -2,7 +2,8 @@ __precompile__()
 
 module FourierFlows
 
-using Requires
+using Requires, FFTW, Statistics
+import LinearAlgebra: mul!, ldiv!
 
 export AbstractGrid,
        AbstractParams,
@@ -47,12 +48,11 @@ include("physics/kuramotosivashinsky.jl")
 include("physics/verticallycosineboussinesq.jl")
 include("physics/verticallyfourierboussinesq.jl")
 
-
 # ----------------------
 # CUDA/GPU functionality
 # ----------------------
 
-@require CuArrays begin
+@require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
   using CuArrays
   include("cuda/cuutils.jl")
   include("cuda/cuproblemstate.jl")

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module FourierFlows
 
 using Requires, FFTW, Statistics

--- a/src/cuda/cudomains.jl
+++ b/src/cuda/cudomains.jl
@@ -27,9 +27,7 @@ struct CuTwoDGrid{T} <: AbstractTwoDGrid
   invKKrsq::CuArray{T,2}  # 1/KKrsq, invKKrsq[1, 1]=0
 
   fftplan::CuArrays.FFT.cCuFFTPlan{Complex{T},-1,false,2}
-  ifftplan::Base.DFT.ScaledPlan{Complex{T},CuArrays.FFT.cCuFFTPlan{Complex{T},1,false,2},T}
   rfftplan::CuArrays.FFT.rCuFFTPlan{T,-1,false,2}
-  irfftplan::Base.DFT.ScaledPlan{Complex{T},CuArrays.FFT.rCuFFTPlan{Complex{T},1,false,2},T}
 
   # Range objects that access the aliased part of the wavenumber range
   ialias::UnitRange{Int}
@@ -40,7 +38,7 @@ end
 """
     CuTwoDGrid(nx, Lx, ny=nx, Ly=Lx;  x0=-Lx/2, y0=-Ly/2)
 
-Construct a CuTwoDGrid object. The two-dimensional domain has size `(Lx, Ly)`, 
+Construct a CuTwoDGrid object. The two-dimensional domain has size `(Lx, Ly)`,
 resolution `(nx, ny)` and bottom left corner at `(x0, y0)`. The type of `CuTwoDGrid` is
 inferred from the type of `Lx`.
 """
@@ -86,9 +84,7 @@ function CuTwoDGrid(nx, Lx, ny=nx, Ly=Lx; x0=-0.5*Lx, y0=-0.5*Ly)
 
   # FFT plans
     fftplan = plan_fft(CuArray{Complex{T},2}(nx, ny))
-   ifftplan = plan_ifft(CuArray{Complex{T},2}(nk, nl))
    rfftplan = plan_rfft(CuArray{T,2}(nx, ny))
-  irfftplan = plan_irfft(CuArray{Complex{T},2}(nkr, nl), nx)
 
   # Index endpoints for aliased i, j wavenumbers
   iaL, iaR = Int(floor(nk/3))+1, 2*Int(ceil(nk/3))-1
@@ -100,7 +96,7 @@ function CuTwoDGrid(nx, Lx, ny=nx, Ly=Lx; x0=-0.5*Lx, y0=-0.5*Ly)
 
   CuTwoDGrid(nx, ny, nk, nl, nkr, Lx, Ly, dx, dy, x, y, X, Y,
              k, l, kr, K, L, Kr, Lr, KKsq, invKKsq, KKrsq, invKKrsq,
-             fftplan, ifftplan, rfftplan, irfftplan, ialias, iralias, jalias)
+             fftplan, rfftplan, ialias, iralias, jalias)
 end
 
 """

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -21,9 +21,9 @@ end
 function Diagnostic(calc::Function, prob::FourierFlows.Problem; freq=1, nsteps=1, num=ceil(Int, (nsteps+1)/freq))
   value = calc(prob)
   T = typeof(value)
-  data = Array{T}(num)
-  time = Array{Float64}(num)
-  step = Array{Int}(num)
+  data = Array{T}(undef, num)
+  time = Array{Float64}(undef, num)
+  step = Array{Int}(undef, num)
   data[1] = value
   time[1] = prob.t
   step[1] = prob.step

--- a/src/output.jl
+++ b/src/output.jl
@@ -73,7 +73,7 @@ function saveproblem(prob::AbstractProblem, filename::String)
       file["grid/$field"] = getfield(prob.grid, field)
     end
 
-    for name in fieldnames(prob.params)   # Params
+    for name in fieldnames(typeof(prob.params))   # Params
       field = getfield(prob.params, name)
       if !(typeof(field) <: Function)
         file["params/$name"] = field

--- a/src/output.jl
+++ b/src/output.jl
@@ -4,7 +4,7 @@ export Output, saveoutput, saveproblem, groupsize, savediagnostic
 
 gridfieldstosave = [:nx, :ny, :Lx, :Ly, :X, :Y]
 
-""" 
+"""
     Output(prob, filename, fieldtuples...)
 
 Define output for the Problem prob with fields and functions that calculate
@@ -23,12 +23,12 @@ function Output(prob::Problem, filename::String, fields::Dict{Symbol,Function})
   else
     basefilename = filename
   end
-  
+
   filename = basefilename*".jld2"
   n = 0
   while isfile(filename) # append numbers until unique name is found
     n += 1
-    filename = basefilename * "_$n.jld2" 
+    filename = basefilename * "_$n.jld2"
   end
 
   saveproblem(prob, filename)
@@ -43,7 +43,7 @@ end
 
 getindex(out::Output, key) = out.fields[key](out.prob)
 
-""" 
+"""
     saveoutput(out)
 
 Save current output fields for file in out.filename.
@@ -59,7 +59,7 @@ function saveoutput(out::Output)
   nothing
 end
 
-""" 
+"""
     saveproblem(prob, filename)
 
 Save certain aspects of a problem timestepper, grid, and params. Functions
@@ -90,7 +90,7 @@ saveproblem(out::Output) = saveproblem(out.prob, out.filename)
 
 Save diagnostics to file, labeled by the string diagname.
 """
-function savediagnostic(diag::AbstractDiagnostic, diagname::String, filename::String) 
+function savediagnostic(diag::AbstractDiagnostic, diagname::String, filename::String)
   jldopen(filename, "a+") do file
     file["diags/$diagname/time"] = diag.time
     file["diags/$diagname/data"] = diag.data

--- a/src/physics/verticallyfourierboussinesq.jl
+++ b/src/physics/verticallyfourierboussinesq.jl
@@ -1,5 +1,7 @@
 module VerticallyFourierBoussinesq
-using FourierFlows
+using FourierFlows, FFTW
+
+import LinearAlgebra: mul!, ldiv!
 import FourierFlows: getfieldspecs, structvarsexpr, parsevalsum, parsevalsum2, autoconstructtimestepper
 
 # -------
@@ -37,7 +39,7 @@ function Problem(;
   # Timestepper and eqn options
   stepper = "RK4",
   calcF = nothing,
-  nthreads = Sys.CPU_CORES,
+  nthreads = Sys.CPU_THREADS,
   T = Float64
   )
 
@@ -58,10 +60,10 @@ end
 abstract type TwoModeParams <: AbstractParams end
 
 """
-    Params(nu0, nnu0, nu1, nnu1, f, N, m, Ub, Vb) 
+    Params(nu0, nnu0, nu1, nnu1, f, N, m, Ub, Vb)
 
 Construct parameters for the Two-Fourier-mode Boussinesq problem. Suffix 0
-refers to zeroth mode; 1 to first mode. f, N, m are Coriolis frequency, 
+refers to zeroth mode; 1 to first mode. f, N, m are Coriolis frequency,
 buoyancy frequency, and vertical wavenumber of the first mode, respectively.
 The optional constant background velocity (Ub,Vb) is set to zero by default.
 The viscosity is applied only to the first-mode horizontal velocities.
@@ -73,7 +75,7 @@ struct Params{T} <: TwoModeParams
   nnu1::Int  # Mode-1 hyperviscous order
   mu0::T     # Mode-0 drag / hypoviscosity
   nmu0::Int  # Mode-0 drag / hypoviscous order
-  mu1::T     # Mode-1 drag / hypoviscosity    
+  mu1::T     # Mode-1 drag / hypoviscosity
   nmu1::Int  # Mode-1 drag / hypoviscous order
   f::T       # Planetary vorticity
   N::T       # Buoyancy frequency
@@ -83,7 +85,7 @@ struct Params{T} <: TwoModeParams
 end
 
 Params(nu0, nnu0, nu1, nnu1, f, N, m) = Params(nu0, nnu0, nu1, nnu1, f, N, m, Ub, Vb)
-  
+
 
 # ---------
 # Equations
@@ -95,11 +97,11 @@ function Equation(p::TwoModeParams, g::TwoDGrid)
 end
 
 function getlinearcoefficients(p::TwoModeParams, g::TwoDGrid)
-  LCr = @. -p.nu0*g.KKrsq^p.nnu0 - p.mu0*g.KKrsq^p.nmu0 
+  LCr = @. -p.nu0*g.KKrsq^p.nnu0 - p.mu0*g.KKrsq^p.nmu0
 
   LCc = zeros(g.nk, g.nl, 3)
-  LCc[:, :, 1] = @. -p.nu1*g.KKsq^p.nnu1 - p.mu1*g.KKsq^p.nmu1 
-  LCc[:, :, 2] = @. -p.nu1*g.KKsq^p.nnu1 - p.mu1*g.KKsq^p.nmu1 
+  LCc[:, :, 1] = @. -p.nu1*g.KKsq^p.nnu1 - p.mu1*g.KKsq^p.nmu1
+  LCc[:, :, 2] = @. -p.nu1*g.KKsq^p.nnu1 - p.mu1*g.KKsq^p.nmu1
 
   LCr[1, 1] = 0
   LCc[1 ,1, 1] = 0
@@ -119,16 +121,17 @@ physicalvarsc = [:u, :v, :w, :p, :zeta, :Uu, :Uv, :Up, :Vu, :Vv, :Vp, :uUxvUy, :
 transformvarsr = [ Symbol(var, :h) for var in physicalvarsr ]
 transformvarsc = [ Symbol(var, :h) for var in physicalvarsc ]
 
-varspecs = cat(1, 
+varspecs = cat(
   getfieldspecs(physicalvarsr, :(Array{T,2})),
   getfieldspecs(physicalvarsc, :(Array{Complex{T},2})),
   getfieldspecs(transformvarsr, :(Array{Complex{T},2})),
-  getfieldspecs(transformvarsc, :(Array{Complex{T},2})))
+  getfieldspecs(transformvarsc, :(Array{Complex{T},2})),
+  dims=1)
 
 eval(structvarsexpr(:Vars, varspecs; parent=:VerticallyFourierVars))
 
 function Vars(g)
-  @createarrays typeof(g.Lx) (g.nx, g.ny) Z U V UZuzvw VZvzuw Ux Uy Vx Vy Psi 
+  @createarrays typeof(g.Lx) (g.nx, g.ny) Z U V UZuzvw VZvzuw Ux Uy Vx Vy Psi
   @createarrays Complex{typeof(g.Lx)} (g.nx, g.ny) u v w p zeta Uu Uv Up Vu Vv Vp uUxvUy uVxvVy
   @createarrays Complex{typeof(g.Lx)} (g.nkr, g.nl) Zh Uh Vh UZuzvwh VZvzuwh Uxh Uyh Vxh Vyh Psih
   @createarrays Complex{typeof(g.Lx)} (g.nk, g.nl) uh vh wh ph zetah Uuh Uvh Uph Vuh Vvh Vph uUxvUyh uVxvVyh
@@ -164,23 +167,23 @@ function calcN!(Nc, Nr, solc, solr, t, s, v, p, g)
   v.Vh[1, 1] += p.Vb*g.nx*g.ny
 
   # Inverse transforms
-  A_mul_B!(v.Z,  g.irfftplan, v.Zh)
-  A_mul_B!(v.U,  g.irfftplan, v.Uh)
-  A_mul_B!(v.V,  g.irfftplan, v.Vh)
-  A_mul_B!(v.Ux, g.irfftplan, v.Uxh)
-  A_mul_B!(v.Uy, g.irfftplan, v.Uyh)
-  A_mul_B!(v.Vx, g.irfftplan, v.Vxh)
-  A_mul_B!(v.Vy, g.irfftplan, v.Vyh)
+  ldiv!(v.Z,  g.rfftplan, v.Zh)
+  ldiv!(v.U,  g.rfftplan, v.Uh)
+  ldiv!(v.V,  g.rfftplan, v.Vh)
+  ldiv!(v.Ux, g.rfftplan, v.Uxh)
+  ldiv!(v.Uy, g.rfftplan, v.Uyh)
+  ldiv!(v.Vx, g.rfftplan, v.Vxh)
+  ldiv!(v.Vy, g.rfftplan, v.Vyh)
 
-  @views A_mul_B!(v.u, g.ifftplan, solc[:, :, 1])
-  @views A_mul_B!(v.v, g.ifftplan, solc[:, :, 2])
-  @views A_mul_B!(v.p, g.ifftplan, solc[:, :, 3])
+  @views ldiv!(v.u, g.fftplan, solc[:, :, 1])
+  @views ldiv!(v.v, g.fftplan, solc[:, :, 2])
+  @views ldiv!(v.p, g.fftplan, solc[:, :, 3])
 
   @views @. v.zetah = im*g.k*solc[:, :, 2] - im*g.l*solc[:, :, 1]
   @views @. v.wh = -(g.k*solc[:, :, 1] + g.l*solc[:, :, 2]) / p.m
 
-  A_mul_B!(v.w, g.ifftplan, v.wh)
-  A_mul_B!(v.zeta, g.ifftplan, v.zetah)
+  ldiv!(v.w, g.fftplan, v.wh)
+  ldiv!(v.zeta, g.fftplan, v.zetah)
 
   # Multiplies
   @. v.UZuzvw = (v.U * v.Z
@@ -202,17 +205,17 @@ function calcN!(Nc, Nr, solc, solr, t, s, v, p, g)
   @. v.Vp = v.V * v.p
 
   # Forward transforms
-  A_mul_B!(v.UZuzvwh, g.rfftplan, v.UZuzvw)
-  A_mul_B!(v.VZvzuwh, g.rfftplan, v.VZvzuw)
-  A_mul_B!(v.uUxvUyh, g.fftplan, v.uUxvUy)
-  A_mul_B!(v.uVxvVyh, g.fftplan, v.uVxvVy)
+  mul!(v.UZuzvwh, g.rfftplan, v.UZuzvw)
+  mul!(v.VZvzuwh, g.rfftplan, v.VZvzuw)
+  mul!(v.uUxvUyh, g.fftplan, v.uUxvUy)
+  mul!(v.uVxvVyh, g.fftplan, v.uVxvVy)
 
-  A_mul_B!(v.Uuh, g.fftplan, v.Uu)
-  A_mul_B!(v.Uvh, g.fftplan, v.Uv)
-  A_mul_B!(v.Vuh, g.fftplan, v.Vu)
-  A_mul_B!(v.Vvh, g.fftplan, v.Vv)
-  A_mul_B!(v.Uph, g.fftplan, v.Up)
-  A_mul_B!(v.Vph, g.fftplan, v.Vp)
+  mul!(v.Uuh, g.fftplan, v.Uu)
+  mul!(v.Uvh, g.fftplan, v.Uv)
+  mul!(v.Vuh, g.fftplan, v.Vu)
+  mul!(v.Vvh, g.fftplan, v.Vv)
+  mul!(v.Uph, g.fftplan, v.Up)
+  mul!(v.Vph, g.fftplan, v.Vp)
 
   # Zeroth-mode nonlinear term
   calcN_linearterms!(Nc, Nr, solc, solr, t, s, v, p, g)
@@ -244,10 +247,10 @@ function updatevars!(v, s, p, g)
   Uh1 = deepcopy(v.Uh)
   Vh1 = deepcopy(v.Vh)
 
-  A_mul_B!(v.Psi, g.irfftplan, Psih1)
-  A_mul_B!(v.Z, g.irfftplan, Zh1)
-  A_mul_B!(v.U, g.irfftplan, Uh1)
-  A_mul_B!(v.V, g.irfftplan, Vh1)
+  ldiv!(v.Psi, g.rfftplan, Psih1)
+  ldiv!(v.Z, g.rfftplan, Zh1)
+  ldiv!(v.U, g.rfftplan, Uh1)
+  ldiv!(v.V, g.rfftplan, Vh1)
 
   @views v.uh .= s.solc[:, :, 1]
   @views v.vh .= s.solc[:, :, 2]
@@ -255,10 +258,10 @@ function updatevars!(v, s, p, g)
 
   @. v.wh = -1.0/p.m*(g.k*v.uh + g.l*v.vh)
 
-  A_mul_B!(v.u, g.ifftplan, v.uh)
-  A_mul_B!(v.v, g.ifftplan, v.vh)
-  A_mul_B!(v.p, g.ifftplan, v.ph)
-  A_mul_B!(v.w, g.ifftplan, v.wh)
+  ldiv!(v.u, g.fftplan, v.uh)
+  ldiv!(v.v, g.fftplan, v.vh)
+  ldiv!(v.p, g.fftplan, v.ph)
+  ldiv!(v.w, g.fftplan, v.wh)
   nothing
 end
 updatevars!(prob) = updatevars!(prob.vars, prob.state, prob.params, prob.grid)
@@ -269,7 +272,7 @@ updatevars!(prob) = updatevars!(prob.vars, prob.state, prob.params, prob.grid)
 Set zeroth mode vorticity and update variables.
 """
 function set_Z!(s, v, p, g, Z)
-  A_mul_B!(s.solr, g.rfftplan, Z)
+  mul!(s.solr, g.rfftplan, Z)
   updatevars!(v, s, p, g)
   nothing
 end
@@ -340,7 +343,7 @@ amplitude(k, l), and either total kinetic energy KE or maximum speed maxspeed.
 function set_isotropicwavefield!(s, vs, pr, g, amplitude; KE=1.0, maxspeed=nothing)
   f, N, m = pr.f, pr.N, pr.m # for clarity
   @createarrays Complex{Float64} (g.nx, g.ny) phase u0 v0 p0
-  
+
   # Sum Fourier components
   for k in real.(g.k), l in real.(g.l)
     if amplitude(k, l) > 1e-15
@@ -369,7 +372,7 @@ function set_isotropicwavefield!(s, vs, pr, g, amplitude; KE=1.0, maxspeed=nothi
   set_uvp!(s, vs, pr, g, u0, v0, p0)
   nothing
 end
-set_isotropicwavefield!(prob::AbstractProblem, amplitude; kwargs...) = set_isotropicwavefield!(prob.state, prob.vars, 
+set_isotropicwavefield!(prob::AbstractProblem, amplitude; kwargs...) = set_isotropicwavefield!(prob.state, prob.vars,
   prob.params, prob.grid, amplitude; kwargs...)
 
 
@@ -387,7 +390,7 @@ Returns the domain-averaged energy in the zeroth mode.
   1/(2*g.Lx*g.Ly)*parsevalsum(v.Uh, g)
 end
 @inline mode0energy(prob) = mode0energy(prob.state, prob.vars, prob.grid)
-  
+
 """
     mode1ke(prob)
 
@@ -434,39 +437,39 @@ Returns the extraction of domain-averaged energy extraction by the drag μ.
   @. v.Uh[1, 1] = 0
   p.mu0/(g.Lx*g.Ly)*parsevalsum(v.Uh, g)
 end
-@inline mode0drag(prob) = mode0drag(prob.state, prob.vars, prob.params, prob.grid) 
+@inline mode0drag(prob) = mode0drag(prob.state, prob.vars, prob.params, prob.grid)
 
 """
     mode1dissipation(prob)
 
-Returns the domain-averaged kinetic energy dissipation of the first mode 
+Returns the domain-averaged kinetic energy dissipation of the first mode
 by horizontal viscosity.
 """
 @inline function mode1dissipation(s, v, p, g)
   @views @. v.Uuh = g.k^p.nnu1*s.solc[:, :, 1]
   @views @. v.Vuh = g.l^p.nnu1*s.solc[:, :, 2]
-  2*p.nu1/(g.Lx*g.Ly)*(parsevalsum2(v.Uuh, g) + parsevalsum2(v.Vuh, g))    
+  2*p.nu1/(g.Lx*g.Ly)*(parsevalsum2(v.Uuh, g) + parsevalsum2(v.Vuh, g))
 end
 @inline mode1dissipation(prob) = mode1dissipation(prob.state, prob.vars, prob.params, prob.grid)
 
 """
     mode1drag(prob)
 
-Returns the domain-averaged kinetic energy dissipation of the first mode 
+Returns the domain-averaged kinetic energy dissipation of the first mode
 by horizontal viscosity.
 """
 @inline function mode1drag(s, v, p, g)
   @views @. v.Uuh = g.k^p.nmu1*s.solc[:, :, 1]
   @views @. v.Vuh = g.l^p.nmu1*s.solc[:, :, 2]
   if p.nmu1 != 0 # zero out zeroth mode
-    @views @. v.Uuh[1, :] = 0 
+    @views @. v.Uuh[1, :] = 0
     @views @. v.Vuh[:, 1] = 0
   end
   2*p.mu1/(g.Lx*g.Ly)*(parsevalsum2(v.Uuh, g) + parsevalsum2(v.Vuh, g))
 end
-@inline mode1drag(prob) = mode1drag(prob.state, prob.vars, prob.params, 
+@inline mode1drag(prob) = mode1drag(prob.state, prob.vars, prob.params,
                                     prob.grid)
-                                                  
+
 """
     totalenergy(prob)
 
@@ -490,13 +493,13 @@ function shearp(s, v, p, g)
   @. v.Vxh =  im*g.kr * v.Vh
   @. v.Vyh =  im*g.l  * v.Vh
 
-  A_mul_B!(v.Ux, g.irfftplan, v.Uxh)
-  A_mul_B!(v.Uy, g.irfftplan, v.Uyh)
-  A_mul_B!(v.Vx, g.irfftplan, v.Vxh)
-  A_mul_B!(v.Vy, g.irfftplan, v.Vyh)
+  ldiv!(v.Ux, g.rfftplan, v.Uxh)
+  ldiv!(v.Uy, g.rfftplan, v.Uyh)
+  ldiv!(v.Vx, g.rfftplan, v.Vxh)
+  ldiv!(v.Vy, g.rfftplan, v.Vyh)
 
-  @views A_mul_B!(v.u, g.ifftplan, s.solc[:, :, 1])
-  @views A_mul_B!(v.v, g.ifftplan, s.solc[:, :, 2])
+  @views ldiv!(v.u, g.fftplan, s.solc[:, :, 1])
+  @views ldiv!(v.v, g.fftplan, s.solc[:, :, 2])
 
   @. v.UZuzvw = real( 2.0*abs2(v.u)*v.Ux + 2.0*abs2(v.v)*v.Vy
                        + (conj(v.u)*v.v + v.u*conj(v.v))*(v.Uy + v.Vx) )
@@ -504,7 +507,7 @@ function shearp(s, v, p, g)
   g.dx*g.dy*sum(v.UZuzvw)
 end
 shearp(prob) = shearp(prob.state, prob.vars, prob.params, prob.grid)
-                                        
+
 
 """
     conversion(prob)
@@ -513,8 +516,8 @@ Return the domain-integrated conversion from potential to kinetic energy.
 """
 function conversion(s, v, p, g)
   @views @. v.wh = -(g.k*s.solc[:, :, 1] + g.l*s.solc[:, :, 2]) / p.m
-  @views A_mul_B!(v.p, g.ifftplan, s.solc[:, :, 3])
-  A_mul_B!(v.w, g.ifftplan, v.wh)
+  @views ldiv!(v.p, g.fftplan, s.solc[:, :, 3])
+  ldiv!(v.w, g.fftplan, v.wh)
   # b = i*m*p
   @. v.UZuzvw = real(im*p.m*conj(v.w)*v.p - im*p.m*v.w*conj(v.p))
   g.dx*g.dy*sum(v.UZuzvw)
@@ -536,9 +539,9 @@ end
 
 function mode0apv(s, v::Vars, p::TwoModeParams, g::TwoDGrid)
   v.Z = irfft(s.solr, g.nx)
-  @views A_mul_B!(v.u, g.ifftplan, s.solc[:, :, 1])
-  @views A_mul_B!(v.v, g.ifftplan, s.solc[:, :, 2])
-  @views A_mul_B!(v.p, g.ifftplan, s.solc[:, :, 3])
+  @views ldiv!(v.u, g.fftplan, s.solc[:, :, 1])
+  @views ldiv!(v.v, g.fftplan, s.solc[:, :, 2])
+  @views ldiv!(v.p, g.fftplan, s.solc[:, :, 3])
   mode0apv(v.Z, v.u, v.v, v.p, p, g)
 end
 mode0apv(prob) = mode0apv(prob.state, prob.vars, prob.params, prob.grid)
@@ -555,19 +558,19 @@ function mode1apv(Z, s::DualState, v, p, g)
   @views @. v.ph = s.solc[:, :, 3]
   @views @. v.zetah = im*g.k*s.solc[:, :, 2] - im*g.l*s.solc[:, :, 1]
 
-  A_mul_B!(v.p,  g.ifftplan, v.ph)
-  A_mul_B!(v.zeta,  g.ifftplan, v.zetah)
+  ldiv!(v.p,  g.fftplan, v.ph)
+  ldiv!(v.zeta,  g.fftplan, v.zetah)
 
   mode1apv(Z, v.zeta, v.p, p, g)
 end
 
 function mode1apv(s::DualState, v, p, g)
   v.Zh .= s.solr
-  A_mul_B!(v.Z, g.irfftplan, v.Zh)
+  ldiv!(v.Z, g.rfftplan, v.Zh)
   mode1apv(v.Z, v, p, g)
 end
 mode1apv(prob) = mode1apv(prob.state, prob.vars, prob.params, prob.grid)
-                                           
+
 
 """
     mode1u(prob)

--- a/src/problemstate.jl
+++ b/src/problemstate.jl
@@ -56,12 +56,12 @@ end
 
 Problem(g, v, p, eq, ts, st) = Problem(g, v, p, eq, ts, st, st.t, st.step)
 
-function Problem(g, v, p, eq::Equation, ts; cxsol=true) 
+function Problem(g, v, p, eq::Equation, ts; cxsol=true)
   Tsol = cxsol ? cxeltype(eq.LC) : eltype(eq.LC)
   Problem(g, v, p, eq, ts, State(Tsol, size(eq.LC), ts.dt))
 end
 
-function Problem(g, v, p, eq::DualEquation, ts; cxsolc=true, cxsolr=true) 
+function Problem(g, v, p, eq::DualEquation, ts; cxsolc=true, cxsolr=true)
   Tc = cxsolc ? cxeltype(eq.LCc) : eltype(eq.LCc)
   Tr = cxsolr ? cxeltype(eq.LCr) : eltype(eq.LCr)
   Problem(g, v, p, eq, ts, DualState(Tc, Tr, size(eq.LCc), size(eq.LCr), ts.c.dt))
@@ -72,7 +72,7 @@ end
 For Julia v1.0 release:
   The `t` and `step` properties can be removed from Problem, instead
   overloading the `getfield` function to intercept attempts to access
-  `t` and `step`, which will be redirected to prob.state.t and 
+  `t` and `step`, which will be redirected to prob.state.t and
   prob.state.step (and perhaps sol as well). This'll make lots of things
   just a little bit nicer.
 
@@ -92,7 +92,7 @@ end
 For Julia v1.0 release:
   The `t` and `step` properties can be removed from Problem, instead
   overloading the `getfield` function to intercept attempts to access
-  `t` and `step`, which will be redirected to prob.state.t and 
+  `t` and `step`, which will be redirected to prob.state.t and
   prob.state.step (and perhaps sol as well). This'll make lots of things
   just a little bit nicer.
 

--- a/src/timesteppers.jl
+++ b/src/timesteppers.jl
@@ -52,7 +52,7 @@ calculating these coefficients.
 """
 function getetdcoeffs(dt, LC; ncirc=32, rcirc=1)
 
-  shape = Tuple(cat(1, ncirc, ones(Int, ndims(LC))))
+  shape = Tuple(cat(ncirc, ones(Int, ndims(LC)), dims=1))
 
   circ = zeros(cxeltype(LC), shape)
   circ .= rcirc * exp.(2π*im/ncirc*(0.5:1:(ncirc-0.5)))
@@ -68,15 +68,15 @@ function getetdcoeffs(dt, LC; ncirc=32, rcirc=1)
   Γc = @. ( -4 - 3zc - zc^2 + exp(zc)*(4 - zc) ) / zc^3
 
   if eltype(LC) <: Real
-    ζ = dt*real.(squeeze(mean(ζc, M), M))
-    α = dt*real.(squeeze(mean(αc, M), M))
-    β = dt*real.(squeeze(mean(βc, M), M))
-    Γ = dt*real.(squeeze(mean(Γc, M), M))
+    ζ = dt*real.(dropdims(mean(ζc, dims=M), dims=M))
+    α = dt*real.(dropdims(mean(αc, dims=M), dims=M))
+    β = dt*real.(dropdims(mean(βc, dims=M), dims=M))
+    Γ = dt*real.(dropdims(mean(Γc, dims=M), dims=M))
   else
-    ζ = dt*squeeze(mean(ζc, M), M)
-    α = dt*squeeze(mean(αc, M), M)
-    β = dt*squeeze(mean(βc, M), M)
-    Γ = dt*squeeze(mean(Γc, M), M)
+    ζ = dt*dropdims(mean(ζc, dims=M), dims=M)
+    α = dt*dropdims(mean(αc, dims=M), dims=M)
+    β = dt*dropdims(mean(βc, dims=M), dims=M)
+    Γ = dt*dropdims(mean(Γc, dims=M), dims=M)
   end
 
   ζ, α, β, Γ

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,13 @@
 #!/usr/bin/env julia
 
-#using CuArrays
-using Requires
+# using CuArrays
 using FourierFlows
-using Base.Test
+using Requires
+using Test
 
 # Run tests
-tic()
+
+time = @elapsed begin
 
 println("-- Core tests --")
 
@@ -37,6 +38,7 @@ end
 
 println("-- Physics tests --")
 
+
 @testset "Physics: Kuramoto-Sivashinsky" begin
   include("test_kuramotosivashinsky.jl")
 end
@@ -61,7 +63,7 @@ end
   include("test_verticallyfourierboussinesq.jl")
 end
 
-@require CuArrays begin
+@require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
 
   println("-- CUDA tests --")
 
@@ -72,4 +74,5 @@ end
 
 end
 
-println("Total test time: ", toq())
+end
+println("Total test time: ", time)

--- a/test/test_fft.jl
+++ b/test/test_fft.jl
@@ -1,17 +1,19 @@
+using LinearAlgebra, FFTW
+
 function create_testfuncs(g::OneDGrid)
-    if nx <= 8; error("nx must be > 8."); end
+    if nx <= 8; error("nx must be > 8"); end
 
     m = 5
     k0 = g.k[2] # Fundamental wavenumber
 
     # Test function
     φ = π/3
-    f1 = cos.(m*k0*g.x + φ)
+    f1 = cos.(m*k0*g.x .+ φ)
     f1h = fft(f1)
     f1hr = rfft(f1)
 
     f1hr_mul = zeros(Complex{eltype(g.x)}, g.nkr)
-    A_mul_B!(f1hr_mul, g.rfftplan, f1)
+    mul!(f1hr_mul, g.rfftplan, f1)
 
     # Theoretical values of the fft and rfft
     f1h_th = zeros(Complex{Float64}, size(f1h))
@@ -34,7 +36,7 @@ end
 
 
 function create_testfuncs(g::TwoDGrid)
-    if nx <= 8; error("nx must be > 8."); end
+    if nx <= 8; error("nx must be > 8"); end
 
     m, n = 5, 2
     k0 = g.k[2] # fundamental wavenumber
@@ -51,8 +53,8 @@ function create_testfuncs(g::TwoDGrid)
 
     f1hr_mul = zeros(Complex{eltype(g.x)}, (g.nkr, g.nl))
     f2hr_mul = zeros(Complex{eltype(g.x)}, (g.nkr, g.nl))
-    A_mul_B!(f1hr_mul, g.rfftplan, f1)
-    A_mul_B!(f2hr_mul, g.rfftplan, f2)
+    mul!(f1hr_mul, g.rfftplan, f1)
+    mul!(f2hr_mul, g.rfftplan, f2)
 
     # Theoretical results
     f1h_th = zeros(Complex{eltype(g.x)}, size(f1h))
@@ -103,7 +105,7 @@ function test_rfft_cosmx(g::OneDGrid)
     isapprox(f1hr, f1hr_th, rtol=rtol)
 end
 
-function test_rfft_AmulB_cosmx(g::OneDGrid)
+function test_rfft_mul_cosmx(g::OneDGrid)
     f1, f1h, f1hr, f1hr_mul, f1h_th, f1hr_th = create_testfuncs(g)
     isapprox(f1hr_mul, f1hr_th, rtol=rtol)
 end
@@ -120,14 +122,14 @@ function test_rfft_cosmxcosny(g::TwoDGrid)
     isapprox(f1hr, f1hr_th, rtol=rtol)
 end
 
-function test_rfft_AmulB_cosmxcosny(g::TwoDGrid)
+function test_rfft_mul_cosmxcosny(g::TwoDGrid)
     f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
     isapprox(f1hr_mul, f1hr_th, rtol=rtol)
 end
 
 function test_fft_sinmxny(g::TwoDGrid)
-    f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
+    f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mulPk, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
     isapprox(f2h, f2h_th, rtol=rtol)
 end
@@ -138,7 +140,7 @@ function test_rfft_sinmxny(g::TwoDGrid)
     isapprox(f2hr, f2hr_th, rtol=rtol)
 end
 
-function test_rfft_AmulB_sinmxny(g::TwoDGrid)
+function test_rfft_mul_sinmxny(g::TwoDGrid)
     f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
     isapprox(f2hr_mul, f2hr_th, rtol=rtol)
@@ -156,11 +158,11 @@ g2 = TwoDGrid(nx, Lx, ny, Ly)
 
 @test test_fft_cosmx(g1)
 @test test_rfft_cosmx(g1)
-@test test_rfft_AmulB_cosmx(g1)
+@test test_rfft_mul_cosmx(g1)
 
 @test test_fft_cosmxcosny(g2)
 @test test_rfft_cosmxcosny(g2)
-@test test_rfft_AmulB_cosmxcosny(g2)
+@test test_rfft_mul_cosmxcosny(g2)
 @test test_fft_sinmxny(g2)
 @test test_rfft_sinmxny(g2)
-@test test_rfft_AmulB_sinmxny(g2)
+@test test_rfft_mul_sinmxny(g2)

--- a/test/test_grid.jl
+++ b/test/test_grid.jl
@@ -1,20 +1,22 @@
+rtol = 1e-15
+
 # Physical grid tests
 testdx(g) = abs(sum(g.x[2:end].-g.x[1:end-1]) - (g.nx-1)*g.dx) < 1e-15*(g.nx-1)
 testdy(g) = abs(sum(g.y[2:end].-g.y[1:end-1]) - (g.ny-1)*g.dy) < 1e-15*(g.nx-1)
 
-testx(g) = g.x[end]-g.x[1] == g.Lx-g.dx
-testy(g) = g.y[end]-g.y[1] == g.Ly-g.dy
+testx(g) = isapprox(g.x[end]-g.x[1], g.Lx-g.dx, rtol=rtol)
+testy(g) = isapprox(g.y[end]-g.y[1], g.Ly-g.dy, rtol=rtol)
 
 testX(g) = sum(g.X[end, :].-g.X[1, :]) - (g.Lx-g.dx)*g.ny < 1e-15*g.ny
 testY(g) = sum(g.Y[:, end].-g.Y[:, 1]) - (g.Ly-g.dy)*g.nx < 1e-15*g.nx
 
 # Test proper arrangement of fft wavenumbers
-testk(g) = sum(g.k[2:g.nkr-1] .+ flipdim(g.k[g.nkr+1:end], 1)) == 0.0
+testk(g) = sum(g.k[2:g.nkr-1] .+ reverse(g.k[g.nkr+1:end], dims=1)) == 0.0
 testkr(g) = sum(g.k[1:g.nkr] .- g.kr) == 0.0
-testl(g) = sum(g.l[:, 2:Int(g.ny/2)] .+ flipdim(g.l[:, Int(g.ny/2+2):end], 2)) == 0.0
+testl(g) = sum(g.l[:, 2:Int(g.ny/2)] .+ reverse(g.l[:, Int(g.ny/2+2):end], dims=2)) == 0.0
 
-testK(g) = sum(g.K[2:g.nkr-1, :] .+ flipdim(g.K[g.nkr+1:end, :], 1)) == 0.0
-testL(g) = sum(g.L[:, 2:Int(g.ny/2)] .+ flipdim(g.L[:, Int(g.ny/2+2):end], 2)) == 0.0
+testK(g) = sum(g.K[2:g.nkr-1, :] .+ reverse(g.K[g.nkr+1:end, :], dims=1)) == 0.0
+testL(g) = sum(g.L[:, 2:Int(g.ny/2)] .+ reverse(g.L[:, Int(g.ny/2+2):end], dims=2)) == 0.0
 testKr(g) = sum(g.K[1:g.nkr, :] .- g.Kr) == 0.0
 testLr(g) = sum(g.L[1:g.nkr, :] .- g.Lr) == 0.0
 

--- a/test/test_ifft.jl
+++ b/test/test_ifft.jl
@@ -22,13 +22,13 @@ function test_irfft_cosmx(g::OneDGrid)
     isapprox(f1, f1b, rtol=rtol)
 end
 
-function test_irfft_AmulB_cosmx(g::OneDGrid)
-    # test irfft with A_mul_B for cos(mx+φ)
+function test_irfft_mul_cosmx(g::OneDGrid)
+    # test irfft with ldiv! for cos(mx+φ)
     f1, f1h, f1hr, f1hr_mul, f1h_th, f1hr_th = create_testfuncs(g)
     f1hr_c = deepcopy(f1hr)
     # deepcopy is needed because FFTW irfft messes up with input!
-    f1b = Array{Float64}(g.nx)
-    A_mul_B!( f1b, g.irfftplan, f1hr_c )
+    f1b = Array{Float64}(undef, g.nx)
+    ldiv!( f1b, g.rfftplan, f1hr_c )
     isapprox(f1, f1b, rtol=rtol)
 end
 
@@ -50,14 +50,14 @@ function test_irfft_cosmxcosny(g::TwoDGrid)
     isapprox(f1, f1b, rtol=rtol)
 end
 
-function test_irfft_AmulB_cosmxcosny(g::TwoDGrid)
-    # test irfft with A_mul_B for cos(mx)cos(ny)
+        function test_irfft_mul_cosmxcosny(g::TwoDGrid)
+    # test irfft with ldiv! for cos(mx)cos(ny)
     f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
     f1hr_c = deepcopy(f1hr)
     # deepcopy is needed because FFTW irfft messes up with input!
-    f1b = Array{Float64}(g.nx, g.ny)
-    A_mul_B!( f1b, g.irfftplan, f1hr_c )
+    f1b = Array{Float64}(undef, g.nx, g.ny)
+    ldiv!( f1b, g.rfftplan, f1hr_c )
     isapprox(f1, f1b, rtol=rtol)
 end
 
@@ -79,14 +79,14 @@ function test_irfft_sinmxny(g::TwoDGrid)
     isapprox(f2, f2b4, rtol=rtol)
 end
 
-function test_irfft_AmulB_sinmxny(g::TwoDGrid)
-    # test irfft with A_mul_B for sin(mx+ny)
+function test_irfft_mul_sinmxny(g::TwoDGrid)
+    # test irfft with ldiv! for sin(mx+ny)
     f1, f2, f1h, f2h, f1hr, f2hr, f1hr_mul, f2hr_mul,
             f1h_th, f1hr_th, f2h_th, f2hr_th = create_testfuncs(g)
     f2hr_c = deepcopy(f2hr)
     # deepcopy is needed because FFTW irfft messes up with input!
-    f2b = Array{Float64}(g.nx, g.ny)
-    A_mul_B!(f2b, g.irfftplan, f2hr_c)
+    f2b = Array{Float64}(undef, g.nx, g.ny)
+    ldiv!(f2b, g.rfftplan, f2hr_c)
     isapprox(f2, f2b, rtol=rtol)
 end
 
@@ -107,11 +107,11 @@ g2 = TwoDGrid(nx, Lx, ny, Ly)
 
 @test test_ifft_cosmx(g1)
 @test test_irfft_cosmx(g1)
-@test test_irfft_AmulB_cosmx(g1)
+@test test_irfft_mul_cosmx(g1)
 
 @test test_ifft_cosmxcosny(g2)
 @test test_irfft_cosmxcosny(g2)
-@test test_irfft_AmulB_cosmxcosny(g2)
+@test test_irfft_mul_cosmxcosny(g2)
 @test test_ifft_sinmxny(g2)
 @test test_irfft_sinmxny(g2)
-@test test_irfft_AmulB_sinmxny(g2)
+@test test_irfft_mul_sinmxny(g2)

--- a/test/test_timesteppers.jl
+++ b/test/test_timesteppers.jl
@@ -2,6 +2,10 @@ import FourierFlows.TwoDTurb
 import FourierFlows.VerticallyFourierBoussinesq
 import FourierFlows.TwoDTurb: energy
 
+using FFTW
+import FFTW: rfft, irfft
+import LinearAlgebra: mul!, ldiv!
+
 # Dictionary of (stepper, nsteps) pairs to test. Each stepper is tested by
 # stepping forward nstep times.
 steppersteps = Dict([
@@ -45,7 +49,7 @@ function testtwodturbstepforward(n=64, L=2π, nu=1e-2, nnu=0; nsteps=100, steppe
   # Remove high wavenumber power from IC
   cutoff = 0.3
   highwavenumbers = @. sqrt((g.Kr*g.dx/π)^2 + (g.Lr*g.dy/π)^2 ) > cutoff
-  qih[highwavenumbers] = 0
+  @. qih[highwavenumbers] = 0
 
   qi = irfft(qih, g.nx)
   qih = rfft(qi)
@@ -86,10 +90,10 @@ function testverticallyfourierstepforward(n=64, L=2π, nu=1e-2, nnu=0; nsteps=10
   cutoff = 0.3
   highwavenumbersr = @. sqrt((g.Kr*g.dx/π)^2 + (g.Lr*g.dy/π)^2 ) > cutoff
   highwavenumbersc = @. sqrt((g.K*g.dx/π)^2 + (g.L*g.dy/π)^2 ) > cutoff
-  Zih[highwavenumbersr] = 0
-  uih[highwavenumbersc] = 0
-  vih[highwavenumbersc] = 0
-  pih[highwavenumbersc] = 0
+  Zih[highwavenumbersr] .= 0
+  uih[highwavenumbersc] .= 0
+  vih[highwavenumbersc] .= 0
+  pih[highwavenumbersc] .= 0
 
   Zi = irfft(Zih, g.nx)
   Zih = rfft(Zi)

--- a/test/test_traceradvdiff.jl
+++ b/test/test_traceradvdiff.jl
@@ -24,7 +24,7 @@ function test_constvel(stepper, dt, nsteps)
 
   c0 = c0func.(g.X, g.Y)
   tfinal = nsteps*dt
-  cfinal = c0func.(g.X-uvel*tfinal, g.Y-vvel*tfinal)
+  cfinal = c0func.(g.X .- uvel*tfinal, g.Y .- vvel*tfinal)
 
   TracerAdvDiff.set_c!(prob, c0)
 
@@ -63,7 +63,7 @@ function test_timedependentvel(stepper, dt, tfinal)
 
   c0 = c0func.(g.X, g.Y)
   tfinal = nsteps*dt
-  cfinal = c0func.(g.X-uvel*tfinal, g.Y)
+  cfinal = c0func.(g.X .- uvel*tfinal, g.Y)
 
   TracerAdvDiff.set_c!(prob, c0func)
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,3 +1,4 @@
+using FFTW
 
 test_fftwavenums() = FourierFlows.fftwavenums(6; L=2π) == [0, 1, 2, 3, -2, -1]
 
@@ -102,9 +103,8 @@ physicalvars = [:a, :b]
 transformvars = [ Symbol(var, :h) for var in physicalvars ]
  forcedvar = [:Fh]
 
-varspecs = cat(1,
-  FourierFlows.getfieldspecs(physicalvars, :(Array{T,2})),
-  FourierFlows.getfieldspecs(transformvars, :(Array{Complex{T},2})))
+varspecs = cat(FourierFlows.getfieldspecs(physicalvars, :(Array{T,2})),
+  FourierFlows.getfieldspecs(transformvars, :(Array{Complex{T},2})), dims=1)
 
 eval(FourierFlows.structvarsexpr(:VarsFields, physicalvars, transformvars))
 eval(FourierFlows.structvarsexpr(:VarsFieldsParent, physicalvars, transformvars; parent=:TestVars))
@@ -197,14 +197,14 @@ f2 = exp.( im*(2k0*x + 3l0*y.^2) ).*(
 k1, l1 = 2*k0, 6*l0
 k2, l2 = 3*k0, -3*l0
 
-sin1 = sin.(k1*x + l1*y)
-sin2 = sin.(k2*x + l2*y)
-exp1 = exp.(im*(k1*x + l1*y))
-exp2 = exp.(im*(k2*x + l2*y))
+sinkl1 = sin.(k1*x + l1*y)
+sinkl2 = sin.(k2*x + l2*y)
+expkl1 = exp.(im*(k1*x + l1*y))
+expkl2 = exp.(im*(k2*x + l2*y))
 
 # Analytical expression for the Jacobian of sin1 and sin2 and of exp1 and exp2
-Jsin1sin2 = (k1*l2-k2*l1)*cos.(k1*x + l1*y).*cos.(k2*x + l2*y)
-Jexp1exp2 = (k2*l1-k1*l2)*exp.(im*((k1+k2)*x + (l1+l2)*y))
+Jsinkl1sinkl2 = (k1*l2-k2*l1)*cos.(k1*x + l1*y).*cos.(k2*x + l2*y)
+Jexpkl1expkl2 = (k2*l1-k1*l2)*exp.(im*((k1+k2)*x + (l1+l2)*y))
 
 @test test_parsevalsum(f1, g; realvalued=true)   # Real valued f with rfft
 @test test_parsevalsum(f1, g; realvalued=false)  # Real valued f with fft
@@ -213,9 +213,9 @@ Jexp1exp2 = (k2*l1-k1*l2)*exp.(im*((k1+k2)*x + (l1+l2)*y))
 @test test_parsevalsum2(f1, g; realvalued=false) # Real valued f with fft
 @test test_parsevalsum2(f2, g; realvalued=false) # Complex valued f with fft
 
-@test test_jacobian(sin1, sin1, 0*sin1, g)  # Test J(a, a) = 0
-@test test_jacobian(sin1, sin2, Jsin1sin2, g) # Test J(sin1, sin2) = Jsin1sin2
-@test test_jacobian(exp1, exp2, Jexp1exp2, g) # Test J(exp1, exp2) = Jexp1exps2
+@test test_jacobian(sinkl1, sinkl1, 0*sinkl1, g)  # Test J(a, a) = 0
+@test test_jacobian(sinkl1, sinkl2, Jsinkl1sinkl2, g) # Test J(sin1, sin2) = Jsin1sin2
+@test test_jacobian(expkl1, expkl2, Jexpkl1expkl2, g) # Test J(exp1, exp2) = Jexp1exps2
 
 @test test_createarrays()
 @test test_fftwavenums()

--- a/test/test_verticallycosineboussinesq.jl
+++ b/test/test_verticallycosineboussinesq.jl
@@ -20,7 +20,6 @@ function test_lambdipole(n, dt; L=2π, Ue=1, Re=L/20, nu0=0, nnu0=1,
 
   # Step forward
   for i = 1:nm
-    tic()
     stepforward!(prob, nt)
     VerticallyCosineBoussinesq.updatevars!(prob)
     xZ[i] = mean(abs.(Z).*x) / mean(abs.(Z))
@@ -32,8 +31,8 @@ function test_lambdipole(n, dt; L=2π, Ue=1, Re=L/20, nu0=0, nnu0=1,
     end
 
     if message
-      @printf("     step: %04d, t: %3.3f, time: %.3f, cfl: %.2f\n",
-        prob.step, prob.t, toq(), cfl(prob))
+      println("     step: %04d, t: %3.3f, time: %.3f, cfl: %.2f\n",
+        prob.step, prob.t, cfl(prob))
     end
   end
 

--- a/test/test_verticallyfourierboussinesq.jl
+++ b/test/test_verticallyfourierboussinesq.jl
@@ -23,7 +23,6 @@ function lambdipoletest(n, dt; L=2π, Ue=1, Re=L/20, nu0=0, nnu0=1,
 
   # Step forward
   for i = 1:nm
-    tic()
     stepforward!(prob, nt)
     VerticallyFourierBoussinesq.updatevars!(prob)
     xZ[i] = mean(abs.(Z).*x) / mean(abs.(Z))
@@ -35,8 +34,8 @@ function lambdipoletest(n, dt; L=2π, Ue=1, Re=L/20, nu0=0, nnu0=1,
     end
 
     if message
-      @printf("     step: %04d, t: %3.3f, time: %.3f, cfl: %.2f\n",
-        prob.step, prob.t, toq(), cfl(prob))
+      println("     step: %04d, t: %3.3f, time: %.3f, cfl: %.2f\n",
+        prob.step, prob.t, cfl(prob))
     end
   end
 


### PR DESCRIPTION
Implements changes to comply with deprecations or change of syntax in `julia v0.7`.

@glwagner: I suggest we make all code compatible with `v0.7` and _then_ we split the physics modules from the main `FourierFlows.jl` code.