### PR TITLE
Clarity refactor

### DIFF
--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -16,7 +16,7 @@ export
 
   OneDGrid, 
   TwoDGrid, 
-  dealias!
+  dealias!,
 
   Diagnostic,
   resize!, 

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -1,18 +1,61 @@
 module FourierFlows
 
-using Requires, FFTW, Statistics
+export 
+  AbstractGrid,
+  AbstractParams,
+  AbstractVars,
+  AbstractEquation,
+  AbstractTimeStepper,
+  AbstractProblem,
+
+  Equation, 
+  DualEquation, 
+  Problem, 
+  State, 
+  DualState,
+
+  OneDGrid, 
+  TwoDGrid, 
+  dealias!
+
+  Diagnostic,
+  resize!, 
+  update!, 
+  increment!,
+    
+  Output, 
+  saveoutput, 
+  saveproblem, 
+  groupsize, 
+  savediagnostic,
+
+  @createarrays, 
+
+  ForwardEulerTimeStepper, 
+  FilteredForwardEulerTimeStepper,
+  RK4TimeStepper, 
+  FilteredRK4TimeStepper,
+  DualRK4TimeStepper, 
+  DualFilteredRK4TimeStepper,
+  ETDRK4TimeStepper, 
+  FilteredETDRK4TimeStepper,
+  DualETDRK4TimeStepper, 
+  DualFilteredETDRK4TimeStepper,
+  AB3TimeStepper, 
+  FilteredAB3TimeStepper,
+  stepforward!
+
+using 
+  Requires, 
+  FFTW, 
+  Statistics,
+  JLD2,
+  Interpolations
+
+using SpecialFunctions: besselj
+
+import Base: resize!, getindex, setindex!, push!, append!, fieldnames
 import LinearAlgebra: mul!, ldiv!
-
-export AbstractGrid,
-       AbstractParams,
-       AbstractVars,
-       AbstractEquation,
-       AbstractTimeStepper,
-       AbstractProblem
-
-# -------------------
-# Abstract supertypes
-# -------------------
 
 abstract type AbstractGrid end
 abstract type AbstractParams end
@@ -22,6 +65,10 @@ abstract type AbstractEquation end
 abstract type AbstractState end
 abstract type AbstractProblem end
 
+abstract type AbstractTwoDGrid <: AbstractGrid end
+abstract type AbstractOneDGrid <: AbstractGrid end
+
+abstract type AbstractDiagnostic end
 
 # ------------------
 # Base functionality

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -1,9 +1,3 @@
-import Base: resize!, getindex
-export AbstractDiagnostic, Diagnostic
-export resize!, update!, increment!
-
-abstract type AbstractDiagnostic end
-
 """ A diagnostic type associated with FourierFlows.Problem types """
 mutable struct Diagnostic{T} <: AbstractDiagnostic
   calc::Function

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -1,8 +1,3 @@
-export OneDGrid, TwoDGrid, dealias!
-
-abstract type AbstractTwoDGrid <: AbstractGrid end
-abstract type AbstractOneDGrid <: AbstractGrid end
-
 """
     ZeroDGrid()
 

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -194,7 +194,7 @@ end
 
 function makefilter(g::AbstractTwoDGrid; realvars=true, kwargs...)
   K = realvars ?
-      @.(sqrt((g.Kr*g.dx/π)^2 + (g.Lr*g.dy/π)^2)) : @.(sqrt((g.K*g.dx/π)^2 + (g.L*g.dy/π)^2))
+      @.(sqrt((g.kr*g.dx/π)^2 + (g.l*g.dy/π)^2)) : @.(sqrt((g.k*g.dx/π)^2 + (g.l*g.dy/π)^2))
   makefilter(K; kwargs...)
 end
 

--- a/src/output.jl
+++ b/src/output.jl
@@ -1,8 +1,4 @@
-using JLD2
-import Base: getindex, setindex!, push!, append!, fieldnames
-export Output, saveoutput, saveproblem, groupsize, savediagnostic
-
-gridfieldstosave = [:nx, :ny, :Lx, :Ly, :X, :Y]
+const gridfieldstosave = [:nx, :ny, :Lx, :Ly, :X, :Y]
 
 """
     Output(prob, filename, fieldtuples...)

--- a/src/problemstate.jl
+++ b/src/problemstate.jl
@@ -1,5 +1,3 @@
-export Equation, DualEquation, Problem, State, DualState
-
 mutable struct State{T,dim} <: AbstractState
   t::Float64
   step::Int

--- a/src/timesteppers.jl
+++ b/src/timesteppers.jl
@@ -1,12 +1,3 @@
-export ForwardEulerTimeStepper, FilteredForwardEulerTimeStepper,
-       RK4TimeStepper, FilteredRK4TimeStepper,
-       DualRK4TimeStepper, DualFilteredRK4TimeStepper,
-       ETDRK4TimeStepper, FilteredETDRK4TimeStepper,
-       DualETDRK4TimeStepper, DualFilteredETDRK4TimeStepper,
-       AB3TimeStepper, FilteredAB3TimeStepper
-
-export stepforward!
-
 """
     stepforward!(prob)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,3 @@
-using Interpolations
-import SpecialFunctions
-
-export @createarrays
-
 """
     cxeltype(a)
 
@@ -158,10 +153,10 @@ function lambdipole(Ue::Real, R::Real, g::TwoDGrid; center=(nothing, nothing))
   xc, yc = center == (nothing, nothing) ? (mean(g.x), mean(g.y)) : (center[1], center[2])
 
   k = 3.8317059702075123156 / R # dipole wavenumber for radius R in terms of first zero of besselj
-  q0 = -2Ue*k/SpecialFunctions.besselj(0, k*R)
+  q0 = -2Ue*k/besselj(0, k*R)
 
   r = @. sqrt((g.x-xc)^2 + (g.y-yc)^2)
-  q = @. q0*SpecialFunctions.besselj(1, k*r)*(g.y-yc)/r
+  q = @. q0*besselj(1, k*r)*(g.y-yc)/r
 
   @. q[r == 0.0] = 0.0 # just in case.
   @. q[r > R] = 0.0


### PR DESCRIPTION
Moves export, using, and import statements to the top-level for clarity.

Also makes a minor change to makefilter that allows us to delete K, L, Kr, Lr from TwoDGrid (not implemented in this PR, but implemented in CuFourierFlows).