### PR TITLE
Fixes the RK4 time-stepper and the Diiffusion test module

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,8 +6,8 @@ authors = ["Gregory L. Wagner <wagner.greg@gmail.com>", "Navid C. Constantinou <
 description = "Solvers for partial differential equations on periodic domains using Fourier-based pseudospectral methods."
 documentation = "https://fourierflows.github.io/FourierFlows.jl/latest/"
 repository = "https://github.com/FourierFlows/FourierFlows.jl"
-version = "0.3.0"
-versions = ["0.0.1", "0.0.2", "0.1.0", "0.1.1", "0.1.2", "0.1.3", "0.2.0", "0.2.1", "0.2.2", "0.3.0"]
+version = "0.2.2"
+versions = ["0.0.1", "0.0.2", "0.1.0", "0.1.1", "0.1.2", "0.1.3", "0.2.0", "0.2.1", "0.2.2"]
 
 [deps]
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -70,7 +70,7 @@ include("utils.jl")
 include("diagnostics.jl")
 include("output.jl")
 include("timesteppers.jl")
-
+println("hi navid")
 # Physics
 include("diffusion.jl")
 

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -70,7 +70,7 @@ include("utils.jl")
 include("diagnostics.jl")
 include("output.jl")
 include("timesteppers.jl")
-println("hi navid")
+
 # Physics
 include("diffusion.jl")
 

--- a/src/diffusion.jl
+++ b/src/diffusion.jl
@@ -5,7 +5,7 @@ export
   updatevars!,
   set_c!
 
-using 
+using
   FFTW,
   Reexport
 
@@ -50,7 +50,7 @@ function Equation(kappa::T, g) where T<:Number
 end
 
 function Equation(kappa::T, g::AbstractGrid{Tg}) where {T<:AbstractArray,Tg}
-  FourierFlows.Equation(0, calcN!, g; dims=(g.nkr,), T=cxtype(Tg))
+  FourierFlows.Equation(0g.kr, calcN!, g; dims=(g.nkr,), T=cxtype(Tg))
 end
 
 # Construct Vars types
@@ -64,7 +64,7 @@ eval(varsexpression(:Vars, physicalvars, fouriervars))
 
 Returns the vars for constant diffusivity problem on grid g.
 """
-function Vars(g::AbstractGrid{T}) where T 
+function Vars(g::AbstractGrid{T}) where T
   @zeros T g.nx c cx
   @zeros Complex{T} g.nkr ch cxh
   Vars(c, cx, ch, cxh)
@@ -75,13 +75,16 @@ end
 
 Calculate the nonlinear term for the 1D heat equation.
 """
-calcN!(N, sol, t, cl, v, p::Params{T}, g) where T<:Number = nothing
+function calcN!(N, sol, t, cl, v, p::Params{T}, g) where T<:Number
+  @. N = 0
+  nothing
+end
 
 function calcN!(N, sol, t, cl, v, p::Params{T}, g) where T<:AbstractArray
   @. v.cxh = im * g.kr * sol
   ldiv!(v.cx, g.rfftplan, v.cxh)
   @. v.cx *= p.kappa
-  ldiv!(v.cxh, g.rfftplan, v.cx)
+  mul!(v.cxh, g.rfftplan, v.cx)
   @. N = im*g.kr*v.cxh
   nothing
 end

--- a/src/timesteppers.jl
+++ b/src/timesteppers.jl
@@ -12,7 +12,7 @@ end
 
 Step forward `prob` for `nsteps`.
 """
-function stepforward!(prob::Problem, nsteps::Int) 
+function stepforward!(prob::Problem, nsteps::Int)
   for step = 1:nsteps
     stepforward!(prob)
   end
@@ -46,12 +46,12 @@ isexplicit(stepper) = any(Symbol(stepper) .== fullyexplicitsteppers)
 
 """
     TimeStepper(stepper, eq, dt=nothing)
-    
+
 Generalized timestepper constructor. If `stepper` is explicit, `dt` is not used.
 """
 function TimeStepper(stepper, eq, dt=nothing)
   fullsteppername = Symbol(stepper, :TimeStepper)
-  if isexplicit(stepper) 
+  if isexplicit(stepper)
     return eval(Expr(:call, fullsteppername, eq))
   else
     return eval(Expr(:call, fullsteppername, eq, dt))
@@ -116,7 +116,7 @@ end
 Construct a forward Euler timestepper with spectral filtering.
 """
 struct FilteredForwardEulerTimeStepper{T,Tf} <: AbstractTimeStepper{T}
-  N::T       
+  N::T
   filter::Tf
 end
 
@@ -147,7 +147,7 @@ const third = 1/3
 Construct a 4th-order Runge-Kutta time stepper.
 """
 struct RK4TimeStepper{T} <: AbstractTimeStepper{T}
-  sol₁::T 
+  sol₁::T
   RHS₁::T
   RHS₂::T
   RHS₃::T
@@ -160,7 +160,7 @@ end
 Construct a 4th-order Runge-Kutta time stepper with spectral filtering for the equation `eq`.
 """
 struct FilteredRK4TimeStepper{T,Tf} <: AbstractTimeStepper{T}
-  sol₁::T 
+  sol₁::T
   RHS₁::T
   RHS₂::T
   RHS₃::T
@@ -185,7 +185,7 @@ function addlinearterm!(RHS, L, sol)
 end
 
 function substepsol!(newsol, sol, RHS, dt)
-  @. newsol = sol + 0.5dt*RHS
+  @. newsol = sol + dt*RHS
   nothing
 end
 
@@ -194,11 +194,11 @@ function RK4substeps!(sol, cl, ts, eq, v, p, g, t, dt)
   eq.calcN!(ts.RHS₁, sol, t, cl, v, p, g)
   addlinearterm!(ts.RHS₁, eq.L, sol)
   # Substep 2
-  substepsol!(ts.sol₁, sol, ts.RHS₁, cl.dt)
+  substepsol!(ts.sol₁, sol, 0.5ts.RHS₁, cl.dt)
   eq.calcN!(ts.RHS₂, ts.sol₁, t+0.5dt, cl, v, p, g)
   addlinearterm!(ts.RHS₂, eq.L, ts.sol₁)
   # Substep 3
-  substepsol!(ts.sol₁, sol, ts.RHS₂, cl.dt)
+  substepsol!(ts.sol₁, sol, 0.5ts.RHS₂, cl.dt)
   eq.calcN!(ts.RHS₃, ts.sol₁, t+0.5dt, cl, v, p, g)
   addlinearterm!(ts.RHS₃, eq.L, ts.sol₁)
   # Substep 4
@@ -213,11 +213,11 @@ function RK4substeps!(sol::AbstractArray{T}, cl, ts, eq, v, p, g) where T<:Abstr
   eq.calcN!(ts.RHS₁, sol, t, cl, v, p, g)
   addlinearterm!.(ts.RHS₁, eq.L, sol)
   # Substep 2
-  substepsol!.(ts.sol₁, sol, ts.RHS₁, cl.dt)
+  substepsol!.(ts.sol₁, sol, 0.5ts.RHS₁, cl.dt)
   eq.calcN!(ts.RHS₂, ts.sol₁, t+0.5dt, cl, v, p, g)
   addlinearterm!.(ts.RHS₂, eq.L, ts.sol₁)
   # Substep 3
-  substepsol!.(ts.sol₁, sol, ts.RHS₂, cl.dt)
+  substepsol!.(ts.sol₁, sol, 0.5ts.RHS₂, cl.dt)
   eq.calcN!(ts.RHS₃, ts.sol₁, t+0.5dt, cl, v, p, g)
   addlinearterm!.(ts.RHS₃, eq.L, ts.sol₁)
   # Substep 4
@@ -272,7 +272,7 @@ Construct a 4th-order exponential-time-differencing Runge-Kutta time stepper. Th
 """
 struct ETDRK4TimeStepper{T,TL} <: AbstractTimeStepper{T}
   # ETDRK4 coefficents
-  ζ::TL 
+  ζ::TL
   α::TL
   β::TL
   Γ::TL
@@ -280,7 +280,7 @@ struct ETDRK4TimeStepper{T,TL} <: AbstractTimeStepper{T}
   expLdt2::TL
   sol₁::T
   sol₂::T
-  N₁::T 
+  N₁::T
   N₂::T
   N₃::T
   N₄::T
@@ -293,15 +293,15 @@ Construct a 4th-order exponential-time-differencing Runge-Kutta time stepper wit
 """
 struct FilteredETDRK4TimeStepper{T,TL,Tf} <: AbstractTimeStepper{T}
   # ETDRK4 coefficents:
-  ζ::TL   
+  ζ::TL
   α::TL
   β::TL
   Γ::TL
   expLdt::TL
   expLdt2::TL
-  sol₁::T 
+  sol₁::T
   sol₂::T
-  N₁::T 
+  N₁::T
   N₂::T
   N₃::T
   N₄::T
@@ -502,14 +502,14 @@ function getexpLs(dt, eq)
   expLdt, expLdt2
 end
 
-function getetdcoeffs(dt, L::AbstractArray{T}; kwargs...) where T<:AbstractArray 
+function getetdcoeffs(dt, L::AbstractArray{T}; kwargs...) where T<:AbstractArray
   ζαβΓ = [ getetdcoeffs(dt, Li) for Li in L ]
   ζ = map(x->x[1], ζαβΓ)
   α = map(x->x[2], ζαβΓ)
   β = map(x->x[3], ζαβΓ)
   Γ = map(x->x[4], ζαβΓ)
   ζ, α, β, Γ
-end 
+end
 
 """
     getetdcoeffs(dt, L; ncirc=32, rcirc=1)
@@ -545,6 +545,6 @@ function getetdcoeffs(dt, L; ncirc=32, rcirc=1)
     β = real.(β)
     Γ = real.(Γ)
   end
- 
+
   ζ, α, β, Γ
 end

--- a/src/timesteppers.jl
+++ b/src/timesteppers.jl
@@ -194,15 +194,15 @@ function RK4substeps!(sol, cl, ts, eq, v, p, g, t, dt)
   eq.calcN!(ts.RHS₁, sol, t, cl, v, p, g)
   addlinearterm!(ts.RHS₁, eq.L, sol)
   # Substep 2
-  substepsol!(ts.sol₁, sol, 0.5ts.RHS₁, cl.dt)
+  substepsol!(ts.sol₁, sol, ts.RHS₁, 0.5dt)
   eq.calcN!(ts.RHS₂, ts.sol₁, t+0.5dt, cl, v, p, g)
   addlinearterm!(ts.RHS₂, eq.L, ts.sol₁)
   # Substep 3
-  substepsol!(ts.sol₁, sol, 0.5ts.RHS₂, cl.dt)
+  substepsol!(ts.sol₁, sol, ts.RHS₂, 0.5dt)
   eq.calcN!(ts.RHS₃, ts.sol₁, t+0.5dt, cl, v, p, g)
   addlinearterm!(ts.RHS₃, eq.L, ts.sol₁)
   # Substep 4
-  substepsol!(ts.sol₁, sol, ts.RHS₃, cl.dt)
+  substepsol!(ts.sol₁, sol, ts.RHS₃, dt)
   eq.calcN!(ts.RHS₄, ts.sol₁, t+dt, cl, v, p, g)
   addlinearterm!(ts.RHS₄, eq.L, ts.sol₁)
   nothing
@@ -213,15 +213,15 @@ function RK4substeps!(sol::AbstractArray{T}, cl, ts, eq, v, p, g) where T<:Abstr
   eq.calcN!(ts.RHS₁, sol, t, cl, v, p, g)
   addlinearterm!.(ts.RHS₁, eq.L, sol)
   # Substep 2
-  substepsol!.(ts.sol₁, sol, 0.5ts.RHS₁, cl.dt)
+  substepsol!.(ts.sol₁, sol, ts.RHS₁, 0.5dt)
   eq.calcN!(ts.RHS₂, ts.sol₁, t+0.5dt, cl, v, p, g)
   addlinearterm!.(ts.RHS₂, eq.L, ts.sol₁)
   # Substep 3
-  substepsol!.(ts.sol₁, sol, 0.5ts.RHS₂, cl.dt)
+  substepsol!.(ts.sol₁, sol, ts.RHS₂, 0.5dt)
   eq.calcN!(ts.RHS₃, ts.sol₁, t+0.5dt, cl, v, p, g)
   addlinearterm!.(ts.RHS₃, eq.L, ts.sol₁)
   # Substep 4
-  substepsol!.(ts.sol₁, sol, ts.RHS₃, cl.dt)
+  substepsol!.(ts.sol₁, sol, ts.RHS₃, dt)
   eq.calcN!(ts.RHS₄, ts.sol₁, t+dt, cl, v, p, g)
   addlinearterm!.(ts.RHS₄, eq.L, ts.sol₁)
   nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ using FourierFlows: parsevalsum2
 using LinearAlgebra: mul!, ldiv!, norm
 
 const rtol_fft = 1e-12
-const rtol_timesteppers = 1e-6
+const rtol_timesteppers = 1e-12
 
 const steppers = [
   "ForwardEuler",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,7 +173,8 @@ end
   include("test_timesteppers.jl")
 
   for stepper in steppers
-    @test diffusiontest(stepper)
+    @test constantdiffusiontest(stepper)
+    @test varyingdiffusiontest(stepper)
   end
 
 end


### PR DESCRIPTION
- corrects substep #4 of `RK4` & `FilteredRK4` time-steppers
- fixes the `calcN!` function for constant diffusivity case
- fixes the `calcN!` function (ldiv! --> mul!) for the case with varying diffusivity
- adds a varying-diffusivity test case so that `stepforward!` calls `calcN!` instead of just `L*sol`
