### PR TITLE
Uses (r)fftfreq to construct wavenumber grids

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ version = "0.3.2"
 versions = ["0.0.1", "0.0.2", "0.1.0", "0.1.1", "0.1.2", "0.1.3", "0.2.0", "0.2.1", "0.2.2", "0.3.0", "0.3.1", "0.3.2"]
 
 [deps]
+AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 CUDAapi = "3895d2a7-ec45-59b8-82bb-cfc6a382f9b3"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
 CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"

--- a/src/CuFourierFlows.jl
+++ b/src/CuFourierFlows.jl
@@ -9,9 +9,9 @@ TwoDGrid(dev::GPU, args...; kwargs...) = TwoDGrid(args...; ArrayType=CuArray, kw
 ThreeDGrid(dev::GPU, args...; kwargs...) = ThreeDGrid(args...; ArrayType=CuArray, kwargs...)
 
 function Base.zeros(::GPU, T, dims)
-    a = CuArray{T}(undef, dims...)
-    a .= 0
-    return a
+  a = CuArray{T}(undef, dims...)
+  a .= 0
+  return a
 end
 
 ArrayType(::GPU) = CuArray
@@ -25,5 +25,5 @@ getetdcoeffs(dt, L::CuArray; kwargs...) =
 makefilter(K::CuArray; kwargs...) = CuArray(makefilter(Array(K); kwargs...))
 
 function makefilter(g::AbstractGrid{Tg, <:CuArray}, T, sz; kwargs...) where Tg
-    CuArray(ones(T, sz)) .* makefilter(g; realvars=sz[1]==g.nkr, kwargs...)
+  CuArray(ones(T, sz)) .* makefilter(g; realvars=sz[1]==g.nkr, kwargs...)
 end

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -3,7 +3,7 @@ module FourierFlows
 export
   # Helper variables and macros for determining if machine is CUDA-enabled.
   @has_cuda,
-  
+
   Device,
   CPU,
   GPU,
@@ -65,6 +65,7 @@ using
 import Base: resize!, getindex, setindex!, lastindex, push!, append!
 
 using Base: fieldnames
+using AbstractFFTs: fftfreq, rfftfreq
 
 abstract type AbstractGrid{T, Ta} end
 abstract type AbstractTimeStepper{T} end

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -57,15 +57,16 @@ function OneDGrid(nx, Lx; x0=-Lx/2, nthreads=Sys.CPU_THREADS, effort=FFTW.MEASUR
                   T=Float64, dealias=1/3, ArrayType=Array)
 
   dx = Lx/nx
-  x = ArrayType{T}(range(x0, step=dx, length=nx))
-
+    
   nk = nx
   nkr = Int(nx/2+1)
 
-  i₁ = 0:Int(nx/2)
-  i₂ = Int(-nx/2+1):-1
-   k = ArrayType{T}(2π/Lx*cat(i₁, i₂; dims=1))
-  kr = ArrayType{T}(2π/Lx*cat(i₁; dims=1))
+  # Physical grid
+   x = ArrayType{T}(range(x0, step=dx, length=nx))
+
+  # Wavenubmer grid
+    k = ArrayType{T}(fftfreq(nx, 2π/Lx*nx))
+   kr = ArrayType{T}(rfftfreq(nx, 2π/Lx*nx))
 
    invksq = @. 1/k^2
   invkrsq = @. 1/kr^2
@@ -137,14 +138,9 @@ function TwoDGrid(nx, Lx, ny=nx, Ly=Lx; x0=-Lx/2, y0=-Ly/2, nthreads=Sys.CPU_THR
   y = ArrayType{T}(reshape(range(y0, step=dy, length=ny), (1, ny)))
 
   # Wavenubmer grid
-  i₁ = 0:Int(nx/2)
-  i₂ = Int(-nx/2+1):-1
-  j₁ = 0:Int(ny/2)
-  j₂ = Int(-ny/2+1):-1
-
-   k = ArrayType{T}(reshape(2π/Lx*cat(i₁, i₂, dims=1), (nk, 1)))
-   l = ArrayType{T}(reshape(2π/Ly*cat(j₁, j₂, dims=1), (1, nl)))
-  kr = ArrayType{T}(reshape(2π/Lx*cat(i₁, dims=1), (nkr, 1)))
+  k = ArrayType{T}(reshape(fftfreq(nx, 2π/Lx*nx), (nk, 1)))
+  l = ArrayType{T}(reshape(fftfreq(ny, 2π/Ly*ny), (1, nl)))
+ kr = ArrayType{T}(reshape(rfftfreq(nx, 2π/Lx*nx), (nkr, 1)))
 
      Ksq = @. k^2 + l^2
   invKsq = @. 1/Ksq
@@ -232,17 +228,10 @@ function ThreeDGrid(nx, Lx, ny=nx, Ly=Lx, nz=nx, Lz=Lx; x0=-Lx/2, y0=-Ly/2, z0=-
   z = ArrayType{T}(reshape(range(z0, step=dz, length=nz), (1, 1, nz)))
 
   # Wavenubmer grid
-  i₁ = 0:Int(nx/2)
-  i₂ = Int(-nx/2+1):-1
-  j₁ = 0:Int(ny/2)
-  j₂ = Int(-ny/2+1):-1
-  k₁ = 0:Int(nz/2)
-  k₂ = Int(-nz/2+1):-1
-
-   k = ArrayType{T}(reshape(2π/Lx*cat(i₁, i₂, dims=1), (nk, 1, 1)))
-   l = ArrayType{T}(reshape(2π/Ly*cat(j₁, j₂, dims=1), (1, nl, 1)))
-   m = ArrayType{T}(reshape(2π/Lz*cat(k₁, k₂, dims=1), (1, 1, nm)))
-  kr = ArrayType{T}(reshape(2π/Lx*cat(i₁, dims=1), (nkr, 1, 1)))
+   k = ArrayType{T}(reshape(fftfreq(nx, 2π/Lx*nx), (nk, 1, 1)))
+   l = ArrayType{T}(reshape(fftfreq(ny, 2π/Ly*ny), (1, nl, 1)))
+   m = ArrayType{T}(reshape(fftfreq(nz, 2π/Lz*nz), (1, 1, nm)))
+  kr = ArrayType{T}(reshape(rfftfreq(nx, 2π/Lx*nx), (nkr, 1, 1)))
 
      Ksq = @. k^2 + l^2 + m^2
   invKsq = @. 1/Ksq

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,7 @@ for dev in devices
     @test testk(g₁)
     @test testkr(g₁)
     @test testdealias(g₁)
+    @test testmakefilter(dev, g₁)
 
     # Test 2D rectangular grid
     g₂ = TwoDGrid(dev, nx, Lx, ny, Ly)
@@ -71,6 +72,7 @@ for dev in devices
     @test testl(g₂)
     @test testgridpoints(g₂)
     @test testdealias(g₂)
+    @test testmakefilter(dev, g₂)
     
     # Test 3D parallelogram grid
     g₃ = ThreeDGrid(dev, nx, Lx, ny, Ly, nz, Lz)
@@ -92,6 +94,7 @@ for dev in devices
     @test testm(g₃)
     @test testgridpoints(g₃)
     @test testdealias(g₃)
+    @test testmakefilter(dev, g₃)
     
     # Test typed grids
     T = Float32

--- a/test/test_grid.jl
+++ b/test/test_grid.jl
@@ -45,11 +45,7 @@ end
 testk(g) = testwavenumberalignment(g.k, g.nx)
 testl(g::Union{TwoDGrid, ThreeDGrid}) = testwavenumberalignment(g.l, g.ny)
 testm(g::ThreeDGrid) = testwavenumberalignment(g.m, g.nz)
-testkr(g) = isapprox(g.k[1:g.nkr], g.kr)
-
-#testk(g) = isapprox(g.k[2:g.nkr-1], flippednegatives(g.k, g.nkr, 1))
-#testk(g) = sum(g.k[2:g.nkr-1] .+ reverse(g.k[g.nkr+1:end], dims=1)) == 0.0
-#testl(g) = sum(g.l[:, 2:Int(g.ny/2)] .+ reverse(g.l[:, Int(g.ny/2+2):end], dims=2)) == 0.0
+testkr(g) = isapprox(cat(g.k[1:g.nkr-1], abs(g.k[g.nkr]), dims=1), g.kr)
 
 function testgridpoints(g::TwoDGrid{T, Ta}) where {T, Ta}
   X, Y = gridpoints(g)

--- a/test/test_grid.jl
+++ b/test/test_grid.jl
@@ -122,3 +122,11 @@ function testtypedthreedgrid(dev::Device, nx, Lx, ny=nx, Ly=Lx, nz=nx, Lz=Lx; T=
   gr = ThreeDGrid(nx, Lx, ny, Ly, nz, Lz, T=T)
   typeof(gr.dx)==T && typeof(gr.dy)==T && typeof(gr.dz)==T && typeof(gr.x[1])==T && typeof(gr.y[1])==T && typeof(gr.z[1])==T && typeof(gr.Lx)==T && typeof(gr.Ly)==T && typeof(gr.Lz)==T 
 end
+
+function testmakefilter(dev::Device, g::AbstractGrid{T}) where T
+  filter = FourierFlows.makefilter(g)
+  G = typeof(g)
+  nofilter = G<:OneDGrid ? filter[@. g.kr*g.dx/π < 0.65] : ( G<:TwoDGrid ? filter[@. sqrt((g.kr*g.dx/π)^2 + (g.l*g.dy/π)^2) < 0.65] : filter[@. sqrt((g.kr*g.dx/π)^2 + (g.l*g.dy/π)^2 + (g.m*g.dz/π)^2) < 0.65] )
+  fullfilter = G<:OneDGrid ? filter[@. g.kr*g.dx/π > 0.999] : ( G<:TwoDGrid ? filter[@. sqrt((g.kr*g.dx/π)^2 + (g.l*g.dy/π)^2) > 0.999] : filter[@. sqrt((g.kr*g.dx/π)^2 + (g.l*g.dy/π)^2 + (g.m*g.dz/π)^2) > 0.999] )
+  nofilter== zeros(dev, T, size(nofilter)) .+ 1 && isapprox(fullfilter, zeros(dev, T, size(fullfilter)), atol=1e-12)
+end


### PR DESCRIPTION
Is this better?
On one had it reduces some boilerplate code. On the other hand we are using other functions...