### PR TITLE
Adds upper bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,12 +23,12 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-CUDAapi = "≥ 1.2.0"
-CuArrays = "≥ 1.6.0"
+CUDAapi = "^ 1.2.0"
+CuArrays = "^ 1.6.0"
 FFTW = "< 1.2"
-Interpolations = "≥ 0.8.0"
-JLD2 = "≥ 0.1.2"
-julia = "≥ 1.0.0"
+Interpolations = "^ 0.8.0"
+JLD2 = "^ 0.1.2"
+julia = "^ 1.0.0"
 
 [extras]
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-CUDAapi = "^1.2.0"
+CUDAapi = "^2"
 CuArrays = "^1.6.0"
 FFTW = "<1.2"
 Interpolations = "^0.12.0"

--- a/Project.toml
+++ b/Project.toml
@@ -23,12 +23,12 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-CUDAapi = "^ 1.2.0"
-CuArrays = "^ 1.6.0"
-FFTW = "< 1.2"
-Interpolations = "^ 0.8.0"
-JLD2 = "^ 0.1.2"
-julia = "^ 1.0.0"
+CUDAapi = "^1.2.0"
+CuArrays = "^1.6.0"
+FFTW = "<1.2"
+Interpolations = "^0.12.0"
+JLD2 = "^0.1.2"
+julia = "^1.0.0"
 
 [extras]
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"


### PR DESCRIPTION
After removing Manifest.toml file compat requires upper bounds for dependencies.