### PR TITLE
Disable multithread for gitlab-ci tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 variables:
   CI_IMAGE_TAG: 'cuda'
-  JULIA_NUM_THREADS: '4'
+  JULIA_NUM_THREADS: '1'
   JULIA_CUDA_VERBOSE: 'true'
 
 # See: https://github.com/JuliaGPU/gitlab-ci
@@ -16,18 +16,11 @@ julia:1.0:
   tags:
     - nvidia
 
-julia:1.1:
-  extends:
-    - .julia:1.1
-    - .test
-  tags:
-    - nvidia
-
 # the "primary" target, where we require a new GPU to make sure all tests are run
-julia:1.2:
+julia:1.3:
   image: juliagpu/cuda:10.1-cudnn7-cutensor1-devel-ubuntu18.04
   extends:
-    - .julia:1.2
+    - .julia:1.3
     - .test
   tags:
     - nvidia
@@ -35,17 +28,8 @@ julia:1.2:
   variables:
     CI_THOROUGH: 'true'
 
-julia:1.3:
-  extends:
-    - .julia:1.3
-    - .test
-  tags:
-    - nvidia
-  allow_failure: true
-
-
 # other tasks
 coverage:
   extends:
-    - .julia:1.2
+    - .julia:1.3
     - .coverage


### PR DESCRIPTION
The PR also drops testing on v1.1, v1.2.

Thanks to @stevengj for suggesting this in  https://github.com/climate-machine/Oceananigans.jl/pull/636