### PR TITLE
Pass kwargs for TimeStepper through Problem

### DIFF
--- a/src/domains.jl
+++ b/src/domains.jl
@@ -358,4 +358,4 @@ function makefilter(g::ThreeDGrid; realvars=true, kwargs...)
 end
 
 makefilter(g, T, sz; kwargs...) = ones(T, sz) .* makefilter(g; realvars=sz[1]==g.nkr, kwargs...)
-makefilter(eq) = makefilter(eq.grid, fltype(eq.T), eq.dims)
+makefilter(eq; kwargs...) = makefilter(eq.grid, fltype(eq.T), eq.dims; kwargs...)

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -36,9 +36,23 @@ end
 struct EmptyParams <: AbstractParams end
 struct EmptyVars <: AbstractVars end
 
-function Problem(eqn::Equation, stepper, dt, grid::AbstractGrid{T, A}, vars=EmptyVars, params=EmptyParams, dev::Device=CPU()) where {T, A}
+"""
+    Problem(eqn::Equation, stepper, dt, grid::AbstractGrid,
+            vars=EmptyVars, params=EmptyParams, dev::Device=CPU(); stepperkwargs...)
+
+Construct a `Problem` for `eqn` using the time`stepper` with timestep `dt`, on `grid` and 
+`dev`ice and with optional `vars`, and `params`. The `stepperkwargs` are passed to the time-stepper
+constructor.
+"""
+function Problem(eqn::Equation, stepper, dt, grid::AbstractGrid{T, A}, 
+                 vars=EmptyVars, params=EmptyParams, dev::Device=CPU(); stepperkwargs...) where {T, A}
+                 
   clock = Clock{T}(dt, 0, 0)
-  timestepper = TimeStepper(stepper, eqn, dt, dev)
+
+  timestepper = TimeStepper(stepper, eqn, dt, dev; stepperkwargs...)
+
   sol = devzeros(dev, eqn.T, eqn.dims)
-  Problem(sol, clock, eqn, grid, vars, params, timestepper)
+
+  return Problem(sol, clock, eqn, grid, vars, params, timestepper)
 end
+

--- a/src/timesteppers.jl
+++ b/src/timesteppers.jl
@@ -59,7 +59,7 @@ function TimeStepper(stepper, eq, dt=nothing, dev::Device=CPU(); kw...)
                                Expr(:call, fullsteppername, eq, dt, dev)
 
   # Add keyword arguments    
-  length(kw) > 0 && push!(expr, Tuple(Expr(:kw, p.first, p.second) for p in kw))
+  length(kw) > 0 && push!(expr.args, Tuple(Expr(:kw, p.first, p.second) for p in kw)...)
 
   return eval(expr)
 end

--- a/src/timesteppers.jl
+++ b/src/timesteppers.jl
@@ -45,17 +45,23 @@ const fullyexplicitsteppers= [
 isexplicit(stepper) = any(Symbol(stepper) .== fullyexplicitsteppers)
 
 """
-    TimeStepper(stepper, eq, dt=nothing)
+    TimeStepper(stepper, eq, dt=nothing, dev=CPU(); kw...)
 
-Generalized timestepper constructor. If `stepper` is explicit, `dt` is not used.
+Instantiate the Time`stepper` for `eq`uation with timestep `dt` and
+on the `dev`ice. The `kw` are passed to the timestepper constructor.
 """
-function TimeStepper(stepper, eq, dt=nothing, dev::Device=CPU())
+function TimeStepper(stepper, eq, dt=nothing, dev::Device=CPU(); kw...)
   fullsteppername = Symbol(stepper, :TimeStepper)
-  if isexplicit(stepper)
-    return eval(Expr(:call, fullsteppername, eq, dev))
-  else
-    return eval(Expr(:call, fullsteppername, eq, dt, dev))
-  end
+
+  # Create expression that instantiates the time-stepper, depending on whether 
+  # timestepper is explicit or not.
+  expr = isexplicit(stepper) ? Expr(:call, fullsteppername, eq, dev) :
+                               Expr(:call, fullsteppername, eq, dt, dev)
+
+  # Add keyword arguments    
+  length(kw) > 0 && push!(expr, Tuple(Expr(:kw, p.first, p.second) for p in kw))
+
+  return eval(expr)
 end
 
 
@@ -70,10 +76,10 @@ end
 #   * AB3
 #   * Filtered AB3
 #
-# Explicit time-steppers are constricted with the signature
+# Explicit time-steppers are constructed with the signature
 #   ts = ExplicitTimeStepper(eq::Equation)
 #
-# Implicit time-steppers are constricted with the signature
+# Implicit time-steppers are constructed with the signature
 #   ts = ImplicitTimeStepper(eq::Equation, dt)
 
 # --

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -256,6 +256,17 @@ for dev in devices
     @test test_radialspectrum(dev, n, ahkl, ahρ; rfft=true)
   end
 
+  @time @testset "Problem instantiation tests" begin
+    include("test_instantiate_problem.jl")  
+
+    for stepper in steppers
+      @test instantiate_problem(dev, stepper)
+      if occursin("Filtered", stepper)
+        @test instantiate_problem_with_filter_kwargs(dev, stepper)
+      end
+    end
+  end
+
   @time @testset "Diagnostics tests" begin
     include("test_diagnostics.jl")
 

--- a/test/test_instantiate_problem.jl
+++ b/test/test_instantiate_problem.jl
@@ -1,0 +1,22 @@
+function instantiate_problem(dev, stepper)
+    problem = Problem(nx=4, dev=dev, stepper=stepper)
+    return typeof(problem) <: FourierFlows.Problem
+end
+
+function instantiate_problem_with_filter_kwargs(dev, stepper)
+    dummy_problem = Problem(nx=16, dev=dev, stepper=stepper)
+
+    real_problem = FourierFlows.Problem(dummy_problem.eqn,
+                                        stepper,
+                                        1.0,
+                                        dummy_problem.grid,
+                                        dummy_problem.vars,
+                                        dummy_problem.params,
+                                        dev,
+                                        innerK=0.0,
+                                        outerK=1/16)
+
+    stepper = real_problem.timestepper
+    
+    return stepper.filter[3] < 1e-16
+end


### PR DESCRIPTION
... and onto the TimeStepper constructor. This allows keyword arguments, such as those specifications for a filter for filtered time-steppers, to be specified in the `Problem` constructor.