### PR TITLE
Updates Documentation: Grids

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,4 +7,4 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-Documenter = "^0.24"
+Documenter = "^0.25"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
 using
   Documenter,
   Literate,
-  Plots,  # to not capture precompilation output
+  Plots,  # so that Literate.jl does not capture precompilation output
   FourierFlows
   
 # Gotta set this environment variable when using the GR run-time on Travis CI.
@@ -41,7 +41,8 @@ Timer(t -> println(" "), 0, interval=240)
 format = Documenter.HTML(
   collapselevel = 2,
      prettyurls = get(ENV, "CI", nothing) == "true",
-      canonical = "https://fourierflows.github.io/FourierFlowsDocumentation/dev/"
+      canonical = "https://fourierflows.github.io/FourierFlowsDocumentation/dev/",
+     # mathengine = Documenter.MathJax()
 )
 
 makedocs(
@@ -54,15 +55,18 @@ makedocs(
    sitename = "FourierFlows.jl",
   
       pages = Any[
-              "Home" => "index.md",
-              "Code Basics" => "basics.md",
-              "Forcing" => "forcing.md",
-              "Examples" => [ 
+                                   "Home" => "index.md",
+              "Installation instructions" => "installation_instructions.md",
+                            "Code Basics" => "basics.md",
+                                  "Grids" => "grids.md",
+                                "Forcing" => "forcing.md",
+                               "Examples" => [ 
                   "generated/OneDShallowWaterGeostrophicAdjustment.md",
-               ],
-              "DocStrings" => Any[
+                                             ],
+                             "DocStrings" => Any[
                   "man/types.md",
-                  "man/functions.md"]
+                  "man/functions.md"
+                                                ]
                  ]
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -48,8 +48,9 @@ format = Documenter.HTML(
 makedocs(
     modules = [FourierFlows],
     doctest = true,
+     strict = true,
       clean = true,
-   checkdocs = :all,
+  checkdocs = :all,
      format = format,
     authors = "Gregory L. Wagner and Navid C. Constantinou",
    sitename = "FourierFlows.jl",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -47,7 +47,7 @@ format = Documenter.HTML(
 
 makedocs(
     modules = [FourierFlows],
-    doctest = false,
+    doctest = true,
       clean = true,
    checkdocs = :all,
      format = format,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -48,7 +48,7 @@ format = Documenter.HTML(
 makedocs(
     modules = [FourierFlows],
     doctest = true,
-     strict = true,
+     # strict = true,
       clean = true,
   checkdocs = :all,
      format = format,

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -7,10 +7,10 @@ The code solves differential equations of the form
 ```math
  \partial_t u = \mathcal{L}u + \mathcal{N}(u)\ ,
 ```
-using Fourier transforms on periodic domains. The right side term $\mathcal{L}u$ is a 'linear' part of the equation.
+using Fourier transforms on periodic domains. Above, $u(\bm{x}, t)$ is the state variable. The right side term $\mathcal{L}u$ is a 'linear' part of the equation.
 The term $\mathcal{N}(u)$ is, in general, a 'nonlinear' part. In FourierFlows, $\mathcal{L}u$ is specified by 
 physical modules in Fourier space as an array with the same size as $\hat u$, the Fourier transform of $u$.
-The nonlinear term $\mathcal{N}u$ is specified by a function.
+The nonlinear term $\mathcal{N}(u)$ is specified via a function.
 
 Boundary conditions in all spatial dimensions are periodic. That allows us to expand all variables using a Fourier 
 decomposition. For example, a variable $\phi(x, t)$ that depends in one spatial dimension is expanded as:

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -7,20 +7,25 @@ The code solves differential equations of the form
 ```math
  \partial_t u = \mathcal{L}u + \mathcal{N}(u)\ ,
 ```
-using Fourier transforms on periodic domains. Above, $u(\bm{x}, t)$ is the state variable. The right side term $\mathcal{L}u$ is a 'linear' part of the equation.
-The term $\mathcal{N}(u)$ is, in general, a 'nonlinear' part. In FourierFlows, $\mathcal{L}u$ is specified by 
-physical modules in Fourier space as an array with the same size as $\hat u$, the Fourier transform of $u$.
-The nonlinear term $\mathcal{N}(u)$ is specified via a function.
+using Fourier transforms on periodic domains. Above, $u(\bm{x}, t)$ is the state 
+variable. On the right-hand-side, term $\mathcal{L}u$ is a 'linear' part of the 
+equation. The term $\mathcal{N}(u)$ is, in general, a 'nonlinear' part.
 
-Boundary conditions in all spatial dimensions are periodic. That allows us to expand all variables using a Fourier 
-decomposition. For example, a variable $\phi(x, t)$ that depends in one spatial dimension is expanded as:
+In FourierFlows.jl, $\mathcal{L}u$ is specified by physical modules as an array 
+with the same dimension as $u$. The nonlinear term $\mathcal{N}(u)$ is specified 
+via a function.
 
+Boundary conditions in all spatial dimensions are periodic. That allows us to 
+expand all variables using a Fourier decomposition. For example, if $u$ depends 
+only in one spatial dimension and it's defined over the domain $x\in[0, L_x]$, 
+then it can be written as:
 
 ```math
-\phi(x, t) = \sum_{k} \widehat{\phi}(k, t)\,e^{\mathrm{i} k x}\ ,
+u(x, t) = \sum_{k} \hat{u}(k, t)\,\mathrm{e}^{\mathrm{i} k x}\ ,
 ```
-where wavenumbers $k$ take the values $\tfrac{2\pi}{L_x}[0,\pm 1,\pm 2,\dots]$. The equation is time-stepped 
-forward in Fourier space. That way $u$ becomes the array with all Fourier coefficients of the solution.
 
-The coefficients for the linear operator $\mathcal{L}$ are stored in an array called `L`. The term $\mathcal{N}(u)$ 
-is computed through the function `calcN!`.
+where wavenumbers $k$ take the values $\tfrac{2\pi}{L_x}[0,\pm 1,\pm 2,\dots]$.
+
+Equations are oftentimes time-stepped forward in Fourier space. That way $u$ 
+becomes the array with all Fourier coefficients of the solution. Although this is
+by any means restictive, it usually enhances performance.

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -5,9 +5,7 @@
 The code solves differential equations of the form
 
 ```math
- \begin{align}
  \partial_t u = \mathcal{L}u + \mathcal{N}(u)\ ,
- \end{align}
 ```
 using Fourier transforms on periodic domains. The right side term $\mathcal{L}u$ is a 'linear' part of the equation.
 The term $\mathcal{N}(u)$ is, in general, a 'nonlinear' part. In FourierFlows, $\mathcal{L}u$ is specified by 

--- a/docs/src/forcing.md
+++ b/docs/src/forcing.md
@@ -297,8 +297,8 @@ Therefore, work for a single forcing realization is computed numerically as:
 
 ```math
 \begin{aligned}
-{\color{Green}\text{Itô}} &: {\color{Green} P_j  =  -\overline{\psi(\boldsymbol{x}, t_j) \xi(\boldsymbol{x}, t_{j+1})}^{x,y}  + \varepsilon},\\
-{\color{Magenta}\text{Stratonovich}} &: {\color{Magenta} P_j = -\overline{\frac{\psi(\boldsymbol{x}, t_j)+\psi(\boldsymbol{x}, t_{j+1})}{2}  \xi(\boldsymbol{x}, t_{j+1}) }^{x,y}}. \tag{eq:PtStrat}
+{\color{Green} \text{Itô}} &: {\color{Green} P_j = -\overline{\psi(\boldsymbol{x}, t_j) \xi(\boldsymbol{x}, t_{j+1})}^{x,y} + \varepsilon},\\
+{\color{Magenta} \text{Stratonovich}} &: {\color{Magenta} P_j = -\overline{\frac{\psi(\boldsymbol{x}, t_j)+\psi(\boldsymbol{x}, t_{j+1})}{2} \xi(\boldsymbol{x}, t_{j+1})}^{x,y}}. \tag{eq:PtStrat}
 \end{aligned}
 ```
 
@@ -308,7 +308,7 @@ Remember, previously the work done by the stochastic forcing was:
 ```
 and by sampling over various forcing realizations:
 ```math
-\langle \mathrm{d} P_t\rangle = \frac{\sigma}{2} \mathrm{d} t = \langle \sqrt{\sigma} x_t \circ \mathrm{d} W_t\rangle
+\langle \mathrm{d} P_t \rangle = \frac{\sigma}{2} \mathrm{d} t = \langle \sqrt{\sigma} x_t \circ \mathrm{d} W_t \rangle
 ```
 
 The code uses Stratonovich. For example, the work done by the forcing in the `TwoDTurb` module is computed based

--- a/docs/src/forcing.md
+++ b/docs/src/forcing.md
@@ -1,120 +1,3 @@
-```math
-\newcommand{\sqr}{\mbox{sqr}}
-\newcommand{\saw}{\mbox{saw}}
-\newcommand{\ind}{\mbox{ind}}
-\newcommand{\sgn}{\mbox{sgn}}
-\newcommand{\erfc}{\mbox{erfc}}
-\newcommand{\erf}{\mbox{erf}}
-
-%% An average
-\newcommand{\avg}[1]{\mathrm{avg}[ {#1} ]}
-%% The right way to define new functions
-\newcommand{\sech}{\mathop{\rm sech}\nolimits}
-\newcommand{\cosech}{\mathop{\rm cosech}\nolimits}
-
-%% A nice definition
-\newcommand{\defn}{\stackrel{\mathrm{def}}{=}}
-%%%%%%%%% %%%%
-
-\newcommand{\ol}[1]{\overline{#1}}
-
-
-%% Various boldsymbols
-\newcommand{\bx}{\boldsymbol{x}}
-\newcommand{\by}{\boldsymbol{y}}
-\newcommand{\bq}{\boldsymbol{q}}
-\newcommand{\bpsi}{\boldsymbol{\psi}}
-\newcommand{\bu}{\boldsymbol{u}}
-\newcommand{\bG}{\boldsymbol{\mathcal{G}}}
-\newcommand{\G}{\mathcal{G}}
-\newcommand{\ba}{\boldsymbol{a}}
-\newcommand{\bb}{\boldsymbol{b}}
-\newcommand{\bc}{\boldsymbol{c}}
-\newcommand{\bv}{\boldsymbol{v}}
-\newcommand{\bk}{\boldsymbol{k}}
-\newcommand{\bX}{\boldsymbol{X}}
-\newcommand{\br}{\boldsymbol{r}}
-\newcommand{\J}{\mathsf{J}}
-\newcommand{\D}{\mathsf{D}}
-\renewcommand{\L}{\mathsf{L}}
-\newcommand{\sL}{\mathsf{L}}
-%\newcommand{\G}{\boldsymbol{\mathsf{G}}}
-\newcommand{\bA}{\boldsymbol {A}}
-\newcommand{\bU}{\boldsymbol {U}}
-\newcommand{\bE}{\boldsymbol {E}}
-\newcommand{\bJ}{\boldsymbol {J}}
-\newcommand{\bXX}{\boldsymbol {\mathcal{X}}}
-\newcommand{\bFF}{\ensuremath {\boldsymbol {F}}}
-\newcommand{\bF}{\ensuremath {\boldsymbol {F}^{\sharp}}}
-\newcommand{\bL}{\ensuremath {\boldsymbol {L}}}
-\newcommand{\bI}{\ensuremath {\boldsymbol {I}}}
-\newcommand{\bN}{\ensuremath {\boldsymbol {N}}}
-
-\newcommand{\I}{\ensuremath {\mathsf{I}}}
-\renewcommand{\L}{\ensuremath {\mathsf{L}}}
-\renewcommand{\S}{\ensuremath {\mathsf{S}}}
-
-\newcommand{\bSigma}{\ensuremath {\boldsymbol {\Sigma}}}
-\newcommand{\kmax}{k_{\mathrm{max}}}
-\newcommand\bnabla{\boldsymbol{\nabla}}
-\newcommand\bcdot{\boldsymbol{\cdot}}
-
-\def\ii{{\rm i}}
-\def\dd{{\rm d}}
-\def\ee{{\rm e}}
-\def\DD{{\rm D}}
-%%% Cals here %%%%%
-
-%%%%%  Euler caligraphics %%%%%
-\newcommand{\A}{\mathscr{A}}
-% \newcommand{\B}{\mathscr{B}}
-\newcommand{\B}{\mathcal{B}}
-\newcommand{\E}{\mathscr{E}}
-\newcommand{\F}{\mathscr{F}}
-\newcommand{\K}{\mathscr{K}}
-\newcommand{\N}{\mathscr{N}}
-\newcommand{\U}{\mathscr{U}}
-\newcommand{\LL}{\mathscr{L}}
-\newcommand{\M}{\mathscr{M}}
-\newcommand{\T}{\mathscr{T}}
-\def\la{\langle}
-\def\ra{\rangle}
-\def\laa{\left \langle}
-\def\raa{\right \rangle}
-\def\Ek{\mathrm{Ek}}
-\newcommand{\hzon}{h_{\mathrm{zon}}}
-\newcommand{\lap}{\triangle}
-\newcommand{\p}{\partial}
-\newcommand{\half }{\tfrac{1}{2}}
-\newcommand{\grad}{\boldsymbol {\nabla}}
-\newcommand{\pde}{\textsc{pde}}
-\newcommand{\ode}{\textsc{ode}}
-\newcommand{\cc}{\textsc{cc}}
-\newcommand{\dc}{\textsc{dc}}
-\newcommand{\dbc}{\textsc{dbc}}
-\newcommand{\byu}{\textsc{byu}}
-\newcommand{\rhs}{\textsc{rhs}}
-\newcommand{\lhs}{\textsc{lhs}}
-\newcommand{\com}{\,,}
-\newcommand{\per}{\,.}
-\newcommand{\z}{\zeta}
-\newcommand{\h}{\eta}
-\renewcommand{\(}{\left(}
-\renewcommand{\[}{\left[}
-\renewcommand{\)}{\right)}
-\renewcommand{\]}{\right]}
-\newcommand{\<}{\left\langle}
-\renewcommand{\>}{\right\rangle}
-\renewcommand{\A}{\mathcal{A}}
-\renewcommand{\N}{\mathcal{N}}
-\newcommand{\C}{\mathcal{C}}
-\newcommand{\transp}{\textrm{T}}
-\newcommand{\zhat}{\widehat{\mathbf{z}}}
-
-\newcommand{\bit}{\vphantom{\dot{W}}}
-\newcommand{\sd}{b}
-```
-
 # Forcing
 
 The code implements forcing in various modules (currently in `TwoDTurb` and `BarotropicQG`). Forcing can be either
@@ -138,33 +21,25 @@ implemented then read on; otherwise you can skip this section of the documentati
 A differential equation in the form:
 
 ```math
-\begin{equation}
-	\frac{\dd x}{\dd t} = f(x)\com\quad x(t_0)=0\com
-\end{equation}
+	\frac{\mathrm{d} x}{\mathrm{d} t} = f(x),\quad x(t_0)=0,
 ```
 
 can also be written in an integral form:
 
 ```math
-\begin{equation}
-	x(t) = \int_{t_0}^{t} f(x(s))\,\dd s\per
-\end{equation}
+	x(t) = \int_{t_0}^{t} f(x(s))\,\mathrm{d} s.
 ```
 
 In a similar manner, a stochastic differential equation
 
 ```math
-\begin{equation}
-	\dd x = f(x)\,\dd t + g(x)\,\dd W_t\com\quad x(t_0)=0\com
-\end{equation}
+	\mathrm{d} x = f(x)\,\mathrm{d} t + g(x)\,\mathrm{d} W_t,\quad x(t_0)=0,
 ```
 
-with $\dd W_t$ a white-noise process, can be written in an integral form as:
+with $\mathrm{d} W_t$ a white-noise process, can be written in an integral form as:
 
 ```math
-\begin{equation}
-	x(t) = \int_{t_0}^{t} f(x(s))\,\dd s + \int_{t_0}^{t} g(x(s))\,\dd W_s \per
-\end{equation}
+	x(t) = \int_{t_0}^{t} f(x(s))\,\mathrm{d} s + \int_{t_0}^{t} g(x(s))\,\mathrm{d} W_s .
 ```
 
 Of course now, the last integral is a stochastic integral and there is not a single straight-forward way of
@@ -172,52 +47,50 @@ computing it --- there are a lot of different ways we can approximate it as a Ri
 leads to a different answer. The two most popular ways for computing such stochastic integrals are:
 
 ```math
-{\color{Green}\text{Itô}: \int_{t_0}^{t} g(x(s))\,\dd W_s\approx\sum_{j} g\left(x(t_j)\right)(W_{j+1}-W_j)}\com\\
-{\color{Magenta}\text{Stratonovich}: \int_{t_0}^{t} g(x(s))\,\dd W_s \approx \sum_{j} g\left(x\left(\half(t_j+t_{j+1})\right)\right)(W_{j+1}-W_j)}\per
+{\color{Green}\text{Itô}: \int_{t_0}^{t} g(x(s))\,\mathrm{d} W_s\approx\sum_{j} g\left(x(t_j)\right)(W_{j+1}-W_j)},\\
+{\color{Magenta}\text{Stratonovich}: \int_{t_0}^{t} g(x(s))\,\mathrm{d} W_s \approx \sum_{j} g\left(x\left(\tfrac{1}{2}(t_j+t_{j+1})\right)\right)(W_{j+1}-W_j)}.
 ```
 
 Because the white noise process is not continuous the two definitions do not converge to the same result; the two
 definitions give thoroughly different results. And to overcome that they come along with different chain rules,
 i.e., chain rules that are not necessarily the same as those in plain old calculus.
 
-An SDE can be written also in differential form. Because we cannot formally form $\dd W/\dd t$, since $W$ is
+An SDE can be written also in differential form. Because we cannot formally form $\mathrm{d} W/\mathrm{d} t$, since $W$ is
 nowhere differentiable, we write an SDE in differential form as:
 
 ```math
-{\color{Green}\text{Itô}: \dd x_t = f(x_t)\dd t + g(x_t)\dd W_t}\com\\
-{\color{Magenta}\text{Stratonovich}: \dd x_t = f(x_t)\dd t + g(x_t)\circ\dd W_t\per}
+{\color{Green}\text{Itô}: \mathrm{d} x_t = f(x_t)\mathrm{d} t + g(x_t)\mathrm{d} W_t},\\
+{\color{Magenta}\text{Stratonovich}: \mathrm{d} x_t = f(x_t) \mathrm{d} t + g(x_t) \circ \mathrm{d} W_t}.
 ```
 
-The circle in $g(x_t)\circ\dd W_t$ is used to differentiate between Itô or Stratonovich calculus.
+The circle in $g(x_t)\circ\mathrm{d} W_t$ is used to differentiate between Itô or Stratonovich calculus.
 
 A variable change $y=G(x)$ is done as follows according to the two different calculi:
 
 ```math
-{\color{Green}\text{Itô}: \dd y_t = \frac{\dd G}{\dd x}\dd x_t + \half g(x_t)^2 \frac{\dd^2 G}{\dd x^2}\dd t =\left[ \frac{\dd G}{\dd x}f(x_t) + \half g(x_t)^2 \frac{\dd^2 G}{\dd x^2}\right]\dd t + \frac{\dd G}{\dd x}g(x_t)\dd W_t}\com\\
-{\color{Magenta}\text{Stratonovich}: \dd y_t  = \frac{\dd G}{\dd x}\dd x_t =\frac{\dd G}{\dd x} f(x_t) \dd t + \frac{\dd G}{\dd x}g(x_t)\circ\dd W_t}\per
+{\color{Green}\text{Itô}: \mathrm{d} y_t = \frac{\mathrm{d} G}{\mathrm{d} x}\mathrm{d} x_t + \tfrac{1}{2} g(x_t)^2 \frac{\mathrm{d}^2 G}{\mathrm{d} x^2}\mathrm{d} t =\left[ \frac{\mathrm{d} G}{\mathrm{d} x}f(x_t) + \tfrac{1}{2} g(x_t)^2 \frac{\mathrm{d}^2 G}{\mathrm{d} x^2}\right]\mathrm{d} t + \frac{\mathrm{d} G}{\mathrm{d} x}g(x_t)\mathrm{d} W_t},\\
+{\color{Magenta}\text{Stratonovich}: \mathrm{d} y_t  = \frac{\mathrm{d} G}{\mathrm{d} x}\mathrm{d} x_t =\frac{\mathrm{d} G}{\mathrm{d} x} f(x_t) \mathrm{d} t + \frac{\mathrm{d} G}{\mathrm{d} x}g(x_t)\circ\mathrm{d} W_t}.
 ```
 
 The above are the so called *stochastic chain rules*. All derivatives of $G$ are evaluated at $x_t$.
 
 It's easy to see that the extra drift-term in Itô's interpretation of the stochastic integral,
-i.e., ${\color{Green}\half g^2\, \dd^2G/\dd x^2}$  is *exactly* equal to the ensemble mean of the
+i.e., ${\color{Green}\tfrac{1}{2} g^2\, \mathrm{d}^2G/\mathrm{d} x^2}$  is *exactly* equal to the ensemble mean of the
 Stratonovich stochastic integral. That's because the Itô stochastic integral has, by construction,
 zero ensemble mean since at every instant the noise is multiplied with $g$ evaluated before the action of the
-noise; $g$ and $\dd W$ are uncorrelated and thus:
+noise; $g$ and $\mathrm{d} W$ are uncorrelated and thus:
 
 ```math
-\begin{equation}
-{\color{Green}\laa g(x_t)\dd W_t \raa =0}\quad\text{while}\quad {\color{Magenta}\laa g(x_t)\circ\dd W_t \raa \ne 0}\per
-\end{equation}
+{\color{Green}\left\langle g(x_t)\mathrm{d} W_t \right\rangle =0}\quad\text{while}\quad {\color{Magenta}\left\langle g(x_t)\circ\mathrm{d} W_t \right\rangle \ne 0}.
 ```
 
 The above is demonstrated by evaluating the simple stochastic integral:
 
 ```math
-{\color{Green}\text{Itô}: \laa \int_{t_0}^{t} W_s\,\dd W_s \raa \approx\sum_{j} \laa W_j(W_{j+1}-W_j)\raa}\\
-{\color{Green}\hspace{7.3em} = \sum_{j} \laa W_j W_{j+1}\raa - \laa W_jW_j\raa \sim \sum_{j} t_j - t_j = 0} \com\\
-{\color{Magenta}\text{Stratonovich}: \laa\int_{t_0}^{t} W_s\circ\dd W_s\raa \approx \sum_{j} \laa \frac1{2}(W_{j} + W_{j+1}) (W_{j+1}-W_j)\raa }\\
-{\color{Magenta}\hspace{7.3em} = \frac1{2}\sum_{j} \laa W_{j+1} W_{j+1}\raa - \laa W_{j} W_{j}\raa  \sim \frac1{2}\sum_{j} t_{j+1} - t_j = \frac{t}{2}}\per
+{\color{Green}\text{Itô}: \left\langle \int_{t_0}^{t} W_s\,\mathrm{d} W_s \right\rangle \approx\sum_{j} \left\langle W_j(W_{j+1}-W_j)\right\rangle}\\
+{\color{Green}\hspace{7.3em} = \sum_{j} \left\langle W_j W_{j+1}\right\rangle - \left\langle W_jW_j\right\rangle \sim \sum_{j} t_j - t_j = 0} ,\\
+{\color{Magenta}\text{Stratonovich}: \left\langle\int_{t_0}^{t} W_s\circ\mathrm{d} W_s\right\rangle \approx \sum_{j} \left\langle \frac1{2}(W_{j} + W_{j+1}) (W_{j+1}-W_j)\right\rangle }\\
+{\color{Magenta}\hspace{7.3em} = \frac1{2}\sum_{j} \left\langle W_{j+1} W_{j+1}\right\rangle - \left\langle W_{j} W_{j}\right\rangle  \sim \frac1{2}\sum_{j} t_{j+1} - t_j = \frac{t}{2}}.
 ```
 
 SDEs rarely can be solved in closed form; most often numerical solution of SDEs is brought to the rescue.
@@ -231,114 +104,100 @@ A nice discussion on the differences and similarities between the two calculi is
 One of the simpler SDEs is the Ornstein--Uhlenbeck process. A variation of which is:
 
 ```math
-\begin{equation}
-	x(t) = \int_{t_0}^{t} -\mu x(s)\,\dd s + \int_{t_0}^{t} \sqrt{\sigma}\,\dd W_s \per\label{eq:OU}
-\end{equation}
+x(t) = \int_{t_0}^{t} -\mu x(s)\,\mathrm{d} s + \int_{t_0}^{t} \sqrt{\sigma}\,\mathrm{d} W_s . \tag{eq:OU}
 ```
 
 Note that in differential form this is:
 
 ```math
-\begin{equation}
-	\dd x_t = -\mu x_t \,\dd t + \sqrt{\sigma}\,\dd W_s \per\label{eq:1}
-\end{equation}
+\mathrm{d} x_t = -\mu x_t \,\mathrm{d} t + \sqrt{\sigma}\,\mathrm{d} W_s . \tag{eq:1}
 ```
 
 Luckily, here there is no need to distinguish between Itô and Stratonovich. This is because $g$ is independent of $x(t)$. But we stress that  this is often not the case; it is only a fortuitous coincident here.
 
 How do we time-step this SDE numerically? Let us assume a discretization of time into time-steps
-of $\tau$: $t_j=(j-1)\tau$. (What follows can be easily transfer to non-uniform time discretization.)
-With that, we denote $x_j\defn x(t_j)$. Then the Euler--Mayorama time-step scheme for \eqref{eq:1} is
+of $\tau$: $t_j=(j-1)\tau$. (What follows can be easily carried on for non-uniform time discretization.)
+With that, we denote $x_j\equiv x(t_j)$. Then the Euler--Mayorama time-step scheme for \eqref{eq:1} is
 
 ```math
-\begin{equation}
-	x_{j+1} = x_j + (-\mu x_j)\tau + \sqrt{\sigma}(W_{j+1}-W_j)\per
-\end{equation}
+	x_{j+1} = x_j + (-\mu x_j)\tau + \sqrt{\sigma}(W_{j+1}-W_j).
 ```
 
 Now let us ask the following question: How can we compute the work done by the noise?
-In other words, if we are interested in the evolution of the "energy" $E\defn \half x^2$, how is the noise term
+In other words, if we are interested in the evolution of the "energy" $E\equiv \tfrac{1}{2} x^2$, how is the noise term
 attributing in the growth of $E$? To answer that we first have to find the SDE that energy $E$ obeys.
-But, in doing so, it is important to adopt a single interpretation for computing stochastic integrals as now a
-transformation of variables is needed. That is, depending on whether we choose to interpret the stochastic integrals
-according to Itô or to Stratonovich calculus, $E$ evolves as:
+But, in doing so, it is important to adopt a single interpretation for computing stochastic integrals as now a transformation of variables is needed. That is, depending on whether we choose to interpret the stochastic integrals according to Itô or to Stratonovich calculus, $E$ evolves as:
 
 ```math
-\begin{equation}
-{\color{Green}\text{Itô}:  \dd E_t  = \left( -2\mu E_t + \half \sigma \right)\dd t  + x_t \sqrt{\sigma}\dd W_t}\com\label{eq:E_ito}
-\end{equation}
+{\color{Green} \text{Itô}: \mathrm{d} E_t = \left ( -2 \mu E_t + \tfrac{1}{2} \sigma \right ) \mathrm{d} t + x_t \sqrt{\sigma} \mathrm{d} W_t } , \tag{eq:Eito}
 ```
 
 ```math
-\begin{equation}
-{\color{Magenta}\text{Stratonovich}: \dd E_t  = -2\mu E_t  \dd t + x_t\circ \sqrt{\sigma}\dd W_t}\per\label{eq:E_str}
-\end{equation}
+{\color{Magenta} \text{Stratonovich}: \mathrm{d} E_t = -2 \mu E_t \mathrm{d} t + x_t \circ \sqrt{\sigma} \mathrm{d} W_t} . \tag{eq:Estr}
 ```
 
 How do we compute the work $P$ done by the noise? It is:
 
 ```math
-{\color{Green}\text{Itô}: P_t = \half \sigma \dd t + \sqrt{\sigma} x_t \dd W_t \approx  \half \sigma + \sqrt{\sigma} x_j (W_{j+1}-W_j)\com}\\
-{\color{Magenta}\text{Stratonovich}: P_t =  x_t \circ\sqrt{\sigma} \dd W_t \approx \sqrt{\sigma} x\left(\half(t_j+t_{j+1})\right)(W_{j+1}-W_j)}\per
+{\color{Green} \text{Itô}: P_t = \tfrac{1}{2} \sigma \mathrm{d} t + \sqrt{\sigma} x_t \mathrm{d} W_t \approx \tfrac{1}{2} \sigma + \sqrt{\sigma} x_j (W_{j+1} - W_j),}\\
+{\color{Magenta} \text{Stratonovich}: P_t =  x_t \circ \sqrt{\sigma} \mathrm{d} W_t \approx \sqrt{\sigma} x \left ( \tfrac{1}{2} (t_j + t_{j+1}) \right ) (W_{j+1}-W_j)}.
 ```
 
 Say we didn't know the rules for transforming Stratonovich to Itô and we were wondering what is the extra drift term
-we have to include in the Itô formulations, i.e. the $\half\sigma$ term. We can compute the Itô's drift-term using
-that it is exactly equal to $\la x_t\circ\sqrt{\sigma}\dd W_t\ra$; and for the latter we can use the "usual" calculus.
+we have to include in the Itô formulations, i.e. the $\tfrac{1}{2}\sigma$ term. We can compute the Itô's drift-term using
+that it is exactly equal to $\langle x_t \circ \sqrt{\sigma} \mathrm{d} W_t \rangle$; and for the latter we can use the "usual" calculus.
 That is, rewrite \eqref{eq:OU} as:
 
 ```math
-\begin{equation}
-\dot{x} = -\mu x + \xi\com\label{eq:OUcont}
-\end{equation}
+\dot{x} = -\mu x + \xi, \tag{eq:OUcont}
 ```
 
 where $\xi(t)$ is understood to be the "continuous" version of the white-noise process which is formally only
 understood in terms of distributions. The forcing $\xi$ has the properties:
 
 ```math
-\laa \xi(t)\raa = 0 \quad\text{and}\quad \laa \xi(t)\xi(t')\raa = \sigma \delta(t-t')\per
+\left \langle \xi(t) \right \rangle = 0 \quad \text{and} \quad \left \langle \xi(t) \xi(t') \right \rangle = \sigma \delta(t-t').
 ```
 
-Thus we need to compute $\la P_t \ra = \la x(t) \xi(t) \ra$. But \eqref{eq:OUcont} has formally the solution:
+Thus we need to compute $\langle P_t \rangle = \langle x(t) \xi(t) \rangle$. But \eqref{eq:OUcont} has formally the solution:
 
 ```math
-x(t) = \ee^{-\mu t} x(0) + \int_0^t \ee^{-\mu(t-s)}\xi(s)\,\dd s\per
+x(t) = \mathrm{e}^{-\mu t} x(0) + \int_0^t \mathrm{e}^{-\mu(t-s)} \xi(s) \, \mathrm{d} s .
 ```
 
 and utilizing the above we get
 
 ```math
-\la P_t \ra = \la x(t) \xi(t)  \ra
-=  \ee^{-\mu t} \underbrace{\la x(0)\xi(t)\ra}_{=0} + \int_0^t \ee^{-\mu(t-s)}\la \xi(t)\xi(s)\ra\,\dd s
-= \sigma \int_0^t \ee^{-\mu(t-s)} \delta(t-s)\,\dd s =  \frac{\sigma}{2} \per
+\langle P_t \rangle = \langle x(t) \xi(t) \rangle
+=  \mathrm{e}^{-\mu t} \underbrace{\langle x(0) \xi(t) \rangle}_{=0} + \int_0^t \mathrm{e}^{-\mu(t-s)} \langle \xi(t)\xi(s) \rangle \, \mathrm{d} s
+= \sigma \int_0^t \mathrm{e}^{-\mu(t-s)} \delta(t-s) \, \mathrm{d} s = \frac{\sigma}{2} .
 ```
 
-Above we used that $\int_0^t\delta(t-s)\dd s = \half$, which is consistent with Stratonovich symmetric interpretation
+Above we used that $\int_0^t\delta(t-s)\mathrm{d} s = \tfrac{1}{2}$, which is consistent with Stratonovich symmetric interpretation
 of stochastic integrals.
 
 ### Numerical implementation
 
-How do we time-step \eqref{eq:E_ito}? We use the Euler--Maruyama time-stepping scheme:
+How do we time-step \eqref{eq:Eito}? We use the Euler--Maruyama time-stepping scheme:
 
 ```math
-	E_{j+1} = E_j + \left(-2\mu E_j + \frac{\sigma}{2}\right)\tau + \sqrt{\sigma}x_j(W_{j+1}-W_j)\per
+	E_{j+1} = E_j + \left(-2\mu E_j + \frac{\sigma}{2}\right)\tau + \sqrt{\sigma}x_j(W_{j+1}-W_j).
 ```
-However, we cannot use Euler--Maruyama for time-stepping \eqref{eq:E_str} since the Euler--Maruyama is "Itô"-thinking.
-To time-step \eqref{eq:E_str} we have to approximate $g$ in the middle of the time-step. There are many ways to do
+However, we cannot use Euler--Maruyama for time-stepping \eqref{eq:Estr} since the Euler--Maruyama is "Itô"-thinking.
+To time-step \eqref{eq:Estr} we have to approximate $g$ in the middle of the time-step. There are many ways to do
 that, one of which is the, so called, Euler--Heun method:
 
 ```math
-	\widetilde{E}_{j+1} = E_j + (-2\mu E_j)\tau + \sqrt{\sigma}x_j(W_{j+1}-W_j)\com\\
-	E_{j+1} = E_j + \left(-2\mu \frac{E_j+\widetilde{E}_{j+1}}{2}\right)\tau + \sqrt{\sigma}\frac{x_j+x_{j+1}}{2}(W_{j+1}-W_j)\per
+	\widetilde{E}_{j+1} = E_j + (-2\mu E_j)\tau + \sqrt{\sigma}x_j(W_{j+1}-W_j),\\
+	E_{j+1} = E_j + \left(-2\mu \frac{E_j+\widetilde{E}_{j+1}}{2}\right)\tau + \sqrt{\sigma}\frac{x_j+x_{j+1}}{2}(W_{j+1}-W_j).
 ```
 
 ![energy_comparison](assets/energy_comparison.png)
 
 Figure above shows a comparison of the energy evolution as done from:
-- direct computation as $\half x_t^2$,
-- time-integration of \eqref{eq:E_ito}, and
-- time-integration of \eqref{eq:E_str}.
+- direct computation as $\tfrac{1}{2} x_t^2$,
+- time-integration of \ref{eq:Eito}, and
+- time-integration of \eqref{eq:Estr}.
 
 Figures below show the ensemble mean energy budgets (using 1000 ensemble members) as computed using Itô and
 Stratonovich. For the energy budget to close we have to be consistent: if we time-step the energy equation based
@@ -352,21 +211,21 @@ on Stratonovich calculus then we must compute the work also according to Straton
 
 We want now to transfer all the knowledge we got from the previous sections to PDEs. In particular we'll focus on the simple SPDE:
 
-\begin{equation}
-\partial_t \nabla^2\psi(\bx, t) =  -\mu \nabla^2\psi(\bx, t) + \xi(\bx,t)\com\label{eq:PDEcont}
-\end{equation}
+```math
+\partial_t \nabla^2\psi(\boldsymbol{x}, t) =  -\mu \nabla^2\psi(\boldsymbol{x}, t) + \xi(\boldsymbol{x},t),\tag{eq:PDEcont}
+```
 
 which is also equivalently written as:
 
 ```math
-\dd \nabla^2\psi_{t}(\bx) = -\mu \nabla^2 \psi_{t} (\bx) \dd t + \sqrt{\sigma} \dd W_{t} (\bx) \per
+\mathrm{d} \nabla^2\psi_{t}(\boldsymbol{x}) = -\mu \nabla^2 \psi_{t} (\boldsymbol{x}) \mathrm{d} t + \sqrt{\sigma} \mathrm{d} W_{t} (\boldsymbol{x}) .
 ```
 
 The form \eqref{eq:PDEcont} is the continuous version understood in the Stratonovich interpretation
 (similar to \eqref{eq:OUcont}). Thus, forcing $\xi$ obeys now:
 
 ```math
-\la\xi(\bx,t)\ra = 0 \quad\text{and}\quad\la\xi(\bx,t)\xi(\bx',t') \ra= Q(\bx-\bx')\delta(t-t')\com
+\langle \xi(\boldsymbol{x},t)\rangle = 0 \quad\text{and}\quad \langle \xi(\boldsymbol{x},t)\xi(\boldsymbol{x}',t') \rangle= Q(\boldsymbol{x}-\boldsymbol{x}')\delta(t-t'),
 ```
 
 that is the forcing is white in time but spatially correlated; its spatial correlation is prescribed by the
@@ -377,14 +236,14 @@ The above describes the vorticity evolution of a two-dimensional fluid $\nabla^2
 forced while dissipated by linear drag $\mu$. The energy of the fluid is:
 
 ```math
-E = \half\overline{|\grad\psi|^2}^{x,y} = -\half\overline{\psi\nabla^2\psi}^{x,y}\com
+E = \tfrac{1}{2}\overline{|\boldsymbol{\nabla}\psi|^2}^{x,y} = -\tfrac{1}{2}\overline{\psi\nabla^2\psi}^{x,y},
 ```
 
 where the overbar denotes average over $x$ and $y$. To obtain the energy equation we multiply
 \eqref{eq:PDEcont} with $-\psi$ and average over the whole domain. Thus, the work done by the forcing is given by the term:
 
 ```math
-P = -\,\overline{\psi\,\xi}^{x,y}\com
+P = -\,\overline{\psi\,\xi}^{x,y},
 ```
 
 but the above is a stochastic integral and it is meaningless without a rule for computing the stochastic integral.
@@ -392,64 +251,64 @@ but the above is a stochastic integral and it is meaningless without a rule for 
 Numerically, the work done by the forcing can be obtained Stratonovich-wise as:
 
 ```math
-\begin{align}
-P_j = -\,\overline{\frac{\psi(\bx,t_j)+\psi(\bx,t_{j+1})}{2}  \xi(\bx,t_{j+1}) }^{x,y}\com
-\end{align}
+\begin{aligned}
+P_j = -\,\overline{\frac{\psi(\boldsymbol{x},t_j)+\psi(\boldsymbol{x},t_{j+1})}{2}  \xi(\boldsymbol{x},t_{j+1}) }^{x,y},
+\end{aligned}
 ```
 
 or Itô-wise
 
 ```math
-\begin{align}
-P_j = -\,\overline{ \psi(\bx,t_j) \xi(\bx,t_{j+1}) }^{x,y} + \text{drift}\com
-\end{align}
+\begin{aligned}
+P_j = -\,\overline{ \psi(\boldsymbol{x},t_j) \xi(\boldsymbol{x},t_{j+1}) }^{x,y} + \text{drift},
+\end{aligned}
 ```
 
 But how much is the Itô drift term in this case? As in the previous section, the drift is *precisely* the ensemble
 mean of the Stratonovich work, i.e.:
 
 ```math
-\textrm{Ito drift}= -\overline{ \la\underbrace{\psi(\bx,t)\circ  \xi(\bx,t)}_{\textrm{Stratonovich}} \ra }^{x,y}\com
+\textrm{Ito drift}= -\overline{\langle \underbrace{\psi(\boldsymbol{x},t)\circ  \xi(\boldsymbol{x},t)}_{\textrm{Stratonovich}} \rangle}^{x,y},
 ```
 
 But again the above can be computed relatively easy if we use the "formal" solution of \eqref{eq:PDEcont}:
 
 ```math
-\psi(\bx,t) = \ee^{-\mu t}\psi(\bx,0) + \int_0^t \ee^{-\mu(t-s)}\nabla^{-2}\xi(\bx,s)\,\dd s\com
+\psi(\boldsymbol{x},t) = \mathrm{e}^{-\mu t}\psi(\boldsymbol{x},0) + \int_0^t \mathrm{e}^{-\mu(t-s)}\nabla^{-2}\xi(\boldsymbol{x},s)\,\mathrm{d} s,
 ```
 
 which implies
 
 ```math
-\text{drift} = -\overline{\ee^{-\mu t}\underbrace{\laa\psi(\bx,0) \xi(\bx,t)\raa}_{=0} }^{x,y} - \int_0^t \ee^{-\mu(t-s)}\overline{\nabla^{-2}\laa \xi(\bx,s)\xi(\bx,t)\raa}^{x,y}\,\dd s \\
-= -\int_0^t \ee^{-\mu(t-s)}\overline{\underbrace{\left[\nabla^{-2} Q(\bx)\right]\big|_{\bx=0}}_{\text{independent of }x,y}\,\delta(t-s)}^{x,y}\,\dd s = -\frac1{2} \nabla^{-2} Q(\bx)\big|_{\bx=0} \\
-= -\frac1{2} \left[\nabla^{-2} \int \frac{\dd^2\bk}{(2\pi)^2} \widehat{Q}(\bk)\,\ee^{\ii\bk\bcdot\bx} \right] _{\bx=0}
-= \int \frac{\dd^2\bk}{(2\pi)^2} \frac{\widehat{Q}(\bk)}{2k^2}\per
+\text{drift} = -\overline{\mathrm{e}^{-\mu t} \underbrace{\left \langle \psi(\boldsymbol{x}, 0)  \xi(\boldsymbol{x}, t) \right \rangle}_{=0}}^{x,y} - \int_0^t \mathrm{e}^{-\mu(t-s)} \overline{\nabla^{-2} \left \langle \xi(\boldsymbol{x}, s) \xi(\boldsymbol{x}, t) \right\rangle}^{x,y}\,\mathrm{d} s \\
+= -\int_0^t \mathrm{e}^{-\mu(t-s)} \overline{\underbrace{\left [ \nabla^{-2} Q (\boldsymbol{x}) \right ] \big|_{\boldsymbol{x}=0}}_{\text{independent of }x,y} \, \delta(t-s)}^{x,y} \, \mathrm{d} s = -\frac1{2} \nabla^{-2} Q(\boldsymbol{x}) \big|_{\boldsymbol{x}=0} \\
+= - \frac1{2} \left [ \nabla^{-2} \int \frac{\mathrm{d}^2 \boldsymbol{k}}{(2\pi)^2} \widehat{Q}(\boldsymbol{k}) \, \mathrm{e}^{\mathrm{i} \boldsymbol{k} \boldsymbol{\cdot}\boldsymbol{x}} \right] _{\boldsymbol{x}=0}
+= \int \frac{\mathrm{d}^2 \boldsymbol{k}}{(2\pi)^2} \frac{\widehat{Q}(\boldsymbol{k})}{2k^2}.
 ```
 
 Thus, the drift, or in this case the mean energy input rate by the stochastic forcing, is precisely determined
 from the spatial correlation of the forcing. Let us denote:
 
 ```math
-\varepsilon \defn \int \frac{\dd^2\bk}{(2\pi)^2} \frac{\widehat{Q}(\bk)}{2k^2}\per\label{eq:def_epsilon}
+\varepsilon \equiv \int \frac{\mathrm{d}^2 \boldsymbol{k}}{(2\pi)^2} \frac{\widehat{Q}(\boldsymbol{k})}{2k^2}. \tag{eq:defepsilon}
 ```
 
 Therefore, work for a single forcing realization is computed numerically as:
 
 ```math
-\begin{align}
-{\color{Green}\text{Itô}}&: {\color{Green} P_j  =  -\overline{ \psi(\bx,t_j) \xi(\bx,t_{j+1}) }^{x,y}  + \varepsilon}\com\\
-{\color{Magenta}\text{Stratonovich}} &: {\color{Magenta}P_j = -\overline{\frac{\psi(\bx,t_j)+\psi(\bx,t_{j+1})}{2}  \xi(\bx,t_{j+1}) }^{x,y}}\per \label{eq:PtStrat}
-\end{align}
+\begin{aligned}
+{\color{Green}\text{Itô}} &: {\color{Green} P_j  =  -\overline{\psi(\boldsymbol{x}, t_j) \xi(\boldsymbol{x}, t_{j+1})}^{x,y}  + \varepsilon},\\
+{\color{Magenta}\text{Stratonovich}} &: {\color{Magenta} P_j = -\overline{\frac{\psi(\boldsymbol{x}, t_j)+\psi(\boldsymbol{x}, t_{j+1})}{2}  \xi(\boldsymbol{x}, t_{j+1}) }^{x,y}}. \tag{eq:PtStrat}
+\end{aligned}
 ```
 
 Remember, previously the work done by the stochastic forcing was:
 ```math
-\dd P_t = {\color{Green}\frac{\sigma}{2}\dd t + \sqrt{\sigma}x_t\dd W_t} = {\color{Magenta}\sqrt{\sigma} x_t\circ\dd W_t}\com
+\mathrm{d} P_t = {\color{Green} \frac{\sigma}{2}\mathrm{d} t + \sqrt{\sigma} x_t \mathrm{d} W_t} = {\color{Magenta} \sqrt{\sigma} x_t \circ \mathrm{d} W_t},
 ```
 and by sampling over various forcing realizations:
 ```math
-\langle \dd P_t\rangle = \frac{\sigma}{2}\dd t = \langle\sqrt{\sigma} x_t\circ\dd W_t\rangle
+\langle \mathrm{d} P_t\rangle = \frac{\sigma}{2} \mathrm{d} t = \langle \sqrt{\sigma} x_t \circ \mathrm{d} W_t\rangle
 ```
 
 The code uses Stratonovich. For example, the work done by the forcing in the `TwoDTurb` module is computed based
@@ -467,29 +326,27 @@ end
 It turns out that nothing changes if we include the nonlinear terms in the vorticity equation:
 
 ```math
-\begin{equation}
-\partial_t \nabla^2\psi(\bx, t) + \J(\psi,\nabla^2\psi) =  -\mu \nabla^2\psi(\bx, t) + \xi(\bx,t)\per\per\label{eq:PDEcont2}
-\end{equation}
+\partial_t \nabla^2 \psi(\boldsymbol{x}, t) + \mathsf{J}(\psi,\nabla^2\psi) =  -\mu \nabla^2\psi(\boldsymbol{x}, t) + \xi(\boldsymbol{x},t). \tag{eq:PDEcont2}
 ```
 
 The nonlinearity does not alter the Itô drift; thus the ensemble mean energy input by the stochastic forcing,
 remains the same. We can easily verify this from the "formal" solution of \eqref{eq:PDEcont2}:
 
 ```math
-\psi(\bx,t) = \ee^{-\mu t}\psi(\bx,0) + \int_0^t \ee^{-\mu(t-s)}\nabla^{-2}\xi(\bx,s)\,\dd s - \int_0^t \nabla^{-2}\J\left(\psi(\bx,s),\nabla^2\psi(\bx,s)\right)\,\dd s\com
+\psi(\boldsymbol{x}, t) = \mathrm{e}^{-\mu t} \psi(\boldsymbol{x}, 0) + \int_0^t \mathrm{e}^{-\mu(t-s)} \nabla^{-2} \xi(\boldsymbol{x}, s) \, \mathrm{d} s - \int_0^t \nabla^{-2} \mathsf{J} \left ( \psi(\boldsymbol{x}, s), \nabla^2 \psi(\boldsymbol{x}, s) \right ) \, \mathrm{d} s,
 ```
 
-When multiplied with $\xi(\bx,t)$ the last term vanishes since its only non-zero contribution comes from the point
+When multiplied with $\xi(\boldsymbol{x}, t)$ the last term vanishes since its only non-zero contribution comes from the point
 $s=t$ which is of measure zero (in the integrated sense).
 
 Figure below shows the energy budgets for a numerical solution of \eqref{eq:PDEcont2}  starting from rest
-($\psi(\bx,0)=0$) in a doubly periodic square domain of size $L$ (`examples/twodturb/IsotropicRingForcing.jl`).
+($\psi(\boldsymbol{x}, 0)=0$) in a doubly periodic square domain of size $L$ (`examples/twodturb/IsotropicRingForcing.jl`).
 The forcing was prescribed to have power in a narrow ring in wavenumber space:
 
 ```math
-\widehat{Q}(\bk)\propto \ee^{-(|\bk|-k_f)^2/(2\delta_f^2)}\com
+\widehat{Q}(\boldsymbol{k}) \propto \mathrm{e}^{-(|\boldsymbol{k}| - k_f)^2 / (2\delta_f^2)},
 ```
 
-with $k_f L/(2\pi) = 12$ and $\delta_f L/(2\pi) = 2$. The mean energy input rate was set to $\varepsilon = 0.1$.
+with $k_f L / (2\pi) = 12$ and $\delta_f L / (2\pi) = 2$. The mean energy input rate was set to $\varepsilon = 0.1$.
 
 ![energy_budgets_SPDE_Stratonovich](assets/energy_budgets_SPDE_Stratonovich.png)

--- a/docs/src/forcing.md
+++ b/docs/src/forcing.md
@@ -1,20 +1,26 @@
 # Forcing
 
-The code implements forcing in various modules (currently in `TwoDTurb` and `BarotropicQG`). Forcing can be either
-deterministic or stochastic (random). For deterministic forcing the implementation is straightforward; for stochastic
-forcing there are two main train of thoughts: Itô calculus and Stratonovich calculus.
+The code implements forcing in various modules. Forcing can be either deterministic 
+or stochastic (random). For deterministic forcing the implementation is 
+straightforward; for stochastic forcing there are two main train of thoughts: 
+Itô calculus and Stratonovich calculus.
 
-Both stochastic calculi give the same results. But once we decide to use one of the two calculi we have to remain
-consistent and use that calculus for everywhere. There is a lot of confusion and mostly the confusion stems from not
-using the same stochastic calculus consistently throughout the computation but rather interchanging between the two.
+Both stochastic calculi give the same results. But once we decide to use one of 
+the two calculi we have to remain consistent and use that calculus for everywhere. 
+There is a lot of confusion and mostly the confusion stems from not using the same 
+stochastic calculus consistently throughout the computation but rather interchanging 
+between the two.
 
-`FourierFlows` uses Stratonovich calculus throughout the code. This choise was made because Stratonovich calculus
-works the same with both stochastic and deterministic forcing, i.e. with Stratonovich calculus we have the same
-chain rules for differentiation for stochastic functions as the chain rules we learn in normal-deterministic calculus).
-Therefore, the code written as is does not really "care" of what forcing the user implements.
+`FourierFlows.jl` uses Stratonovich calculus throughout. This choise was made 
+because Stratonovich calculus works the same with both stochastic and deterministic 
+forcing, i.e. with Stratonovich calculus we have the same chain rules for 
+differentiation for stochastic functions as the chain rules we learn in 
+normal-deterministic calculus). Therefore, the code written as is does not really 
+"care" of what forcing the user implements.
 
-If you are interested in learning more regarding the two stochastic calculi and how they are numerically
-implemented then read on; otherwise you can skip this section of the documentation and go to the Module Tutorials.
+If you are interested in learning more regarding the two stochastic calculi and 
+how they are numerically implemented then read on; otherwise you can skip this 
+section of the documentation.
 
 ## Stochastic Differential Equations (SDEs)
 
@@ -42,9 +48,10 @@ with $\mathrm{d} W_t$ a white-noise process, can be written in an integral form 
 	x(t) = \int_{t_0}^{t} f(x(s))\,\mathrm{d} s + \int_{t_0}^{t} g(x(s))\,\mathrm{d} W_s .
 ```
 
-Of course now, the last integral is a stochastic integral and there is not a single straight-forward way of
-computing it --- there are a lot of different ways we can approximate it as a Riemannian sum and each of them
-leads to a different answer. The two most popular ways for computing such stochastic integrals are:
+Of course now, the last integral is a stochastic integral and there is not a single 
+straight-forward way of computing it --- there are a lot of different ways we can 
+approximate it as a Riemannian sum and each of them leads to a different answer. 
+The two most popular ways for computing such stochastic integrals are:
 
 ```math
 {\color{Green}\text{Itô}: \int_{t_0}^{t} g(x(s))\,\mathrm{d} W_s\approx\sum_{j} g\left(x(t_j)\right)(W_{j+1}-W_j)},\\

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -16,15 +16,15 @@ end
 
 ```jldoctest
 julia> nx, Lx = 64, 2π;
-julia> grid = OneDGrid(nx, Lx)
 
+julia> grid = OneDGrid(nx, Lx)
 OneDimensionalGrid
-                Device: CPU
-             FloatType: Float64
-               size Lx: 6.283185307179586
-         resolution nx: 64
-       grid spacing dx: 0.09817477042468103
-                domain: x ∈ [-3.141592653589793, 3.0434178831651124])
+  ├─────────── Device: CPU
+  ├──────── FloatType: Float64
+  ├────────── size Lx: 6.283185307179586
+  ├──── resolution nx: 64
+  ├── grid spacing dx: 0.09817477042468103
+  └────────── domain: x ∈ [-3.141592653589793, 3.0434178831651124]
 ```
 
 The grid domain is, by default, constructed symmetrically around 0, but this can 
@@ -41,8 +41,8 @@ grid as
 using FourierFlows
 using LinearAlgebra: mul!, ldiv!
 using Plots
-Plots.scalefontsizes(1.5)
-Plots.default(dpi=100)
+Plots.scalefontsizes(1.25)
+Plots.default(lw=2)
 nx, Lx = 64, 2π
 grid = OneDGrid(nx, Lx)
 ```

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -1,0 +1,5 @@
+# Grids
+
+
+We support 1D, 2D, and 3D grids.
+

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -1,9 +1,12 @@
 # Grids
 
 
-1D, 2D, and 3D grids are supported.
+1D, 2D, and 3D grids are supported. We demonstrate here the construction of a 
+one-dimensional grid and how one can use it to perform Fourier transforms and 
+compute spatial derivatives.
 
-A one-dimensional grid with $n_x = 64$ grid points and length $L_x = 2.0$ is constructed using
+A one-dimensional grid with $n_x = 64$ grid points and length $L_x = 2\pi$ is 
+constructed by
 
 ```@meta
 DocTestSetup = quote
@@ -12,46 +15,66 @@ end
 ```
 
 ```jldoctest
-julia> nx, Lx = 64, 2π
+julia> nx, Lx = 64, 2π;
 julia> grid = OneDGrid(nx, Lx)
+
 OneDimensionalGrid
                 Device: CPU
              FloatType: Float64
                size Lx: 6.283185307179586
          resolution nx: 64
        grid spacing dx: 0.09817477042468103
-                domain: x ∈ [-3.141592653589793, 3.0434178831651124])```
+                domain: x ∈ [-3.141592653589793, 3.0434178831651124])
 ```
 
-The grid spacing is simply $L_x/n_x$. Note that $x\in [-L_x/2, L_x/2 - L_x/n_x]$ since periodicity
-implies that the value of any field at $x=L_x/2$ is the same as $x=-L_x/2$.
+The grid domain is, by default, constructed symmetrically around 0, but this can 
+be altered using the `x0` keyword argument of `OneDGrid` constructor. The grid 
+spacing is $L_x/n_x$. Note that the last point of the domain is a grid-spacing 
+before $L_x/2$. This is because periodicity implies that the value of any field 
+at the end-points of the domain are equal and, therefore, grid-point values at
+both these end-points are reduntant.
 
-We can define an array $f$ on this grid as
+We can define an array `f` that contains the values of a function $f(x)$ on this 
+grid as
 
 ```@setup 1
 using FourierFlows
 using LinearAlgebra: mul!, ldiv!
-using Plots # hide
+using Plots
+Plots.scalefontsizes(1.5)
+Plots.default(dpi=100)
 nx, Lx = 64, 2π
 grid = OneDGrid(nx, Lx)
 ```
 
-
 ```@example 1
 f = @. sin(2 * grid.x) + 1/2 * cos(5 * grid.x)
+
 nothing # hide
 ```
 
-and plot it
+Note that we chose a function that *is* periodic on our domain. We can visualize
+`f` by
 
 ```@example 1
 plot(grid.x, f, label="f", xlabel="x")
-savefig("assets/plot1.png"); nothing # hide
+savefig("assets/plot1.svg"); nothing # hide
 ```
 
-![](assets/plot1.png)
+![](assets/plot1.svg)
 
-The Fourier transform of $f$ is $\hat{f}$. Since our `f` array is real-valued then we should use the `real-FFT` algorithm. The real-valued FFT transform only saves the Fourier coefficients for $k\ge 0$; the coefficients for negative wavenumbers can be obtained via $\hat{f}(-k) = \hat{f}(k)^\star$.
+Function $f(x)$ can be expanded in Fourier series:
+
+```math
+f(x) = \sum_{k} \hat{f}(k)\,\mathrm{e}^{\mathrm{i} k x},
+```
+
+where $\hat{f}(k)$ is Fourier transform of $f(x)$ and $k$ the discrete set of 
+wavenumbers that fit within our finite domain. We can compute $\hat{f}$ via a 
+Fast Fourier Transform (FFT). Since our `f` array is real-valued then we should 
+use the `real-FFT` algorithm. The real-valued FFT transform only saves the Fourier 
+coefficients for $k\ge 0$; the coefficients for negative wavenumbers can be 
+obtained via $\hat{f}(-k) = \hat{f}(k)^{*}$.
 
 The `grid` includes the `FFT` plans for both real-valued and complex valued transforms:
 
@@ -63,23 +86,35 @@ grid.fftplan
 grid.rfftplan
 ```
 
-We use the convention that variables names with `h` at the end stand for variable-hat, i.e., $\hat{f}$  is the Fourier transform of $f$ and is stored in array `fh`.
+We use the convention that variables names with `h` at the end stand for variable-hat, i.e., $\hat{f}$  is the Fourier transform of $f$ and is stored in array `fh`. Since `f` is of size $n_x$, the real-Fourier transform should be of size $n_{kr} = n_x/2+1$.
 
 ```@example 1
 fh = zeros(FourierFlows.cxeltype(grid), grid.nkr)
-
 mul!(fh, grid.rfftplan, f)
 
-plot(grid.kr, [real.(fh / nx), imag.(fh / nx)],
-          label = ["real\\( rfft\\(f\\) \\)" "imag\\( rfft\\(f\\) \\)"],
-         xlabel = "k",
-          xlims = (-0.5, 10.5),
-         marker = :auto)
-
-savefig("assets/plot2.png"); nothing # hide
+nothing # hide
 ```
 
-![](assets/plot2.png)
+The `FFT` algorithm does not output exactly the Fourier coefficients $\hat{f}(k)$ but
+rather due to different normalization, `FFT` outputs something proportional to $\hat{f}(k)$. 
+To obtain $\hat{f}$ we need to divide the `FFT` output by the length of the 
+original array and by $\mathrm{e}^{-\mathrm{i} k x_0}$, where $x_0$ is the first 
+point of our domain array.
+
+```@example 1
+fhat = @. fh / (nx * exp(- im * grid.kr * grid.x[1])) # due to normalization of FFT
+
+plot(grid.kr, [real.(fhat), imag.(fhat)],
+          label = ["real\\( f̂ \\)" "imag\\( f̂ \\)"],
+         xlabel = "k",
+          xlims = (-0.5, 10.5),
+         xticks = 0:10,
+         marker = :auto)
+
+savefig("assets/plot2.svg"); nothing # hide
+```
+
+![](assets/plot2.svg)
 
 We can compute its derivative via Fourier transforms. To do that we can use the
 `FFTW` plans that are constructed with the grid. First we allocate an empty array
@@ -88,11 +123,11 @@ where the values of the derivative will be stored,
 ```@example 1
 ∂ₓf = similar(f)
 ∂ₓfh = similar(fh)
-
 nothing # hide
 ```
 
-Array `∂ₓfh` is populated with $\mathrm{i} k \hat{f}$
+The grid contains the wavenumbers (both for real-value functions `grid.kr` and 
+for complex-valued functions `grid.k`). We populate array `∂ₓfh` is with $\mathrm{i} k \hat{f}$:
 
 ```@example 1
 @. ∂ₓfh = im * grid.kr * fh
@@ -100,15 +135,15 @@ Array `∂ₓfh` is populated with $\mathrm{i} k \hat{f}$
 nothing # hide
 ```
 
-Then `∂ₓf` is computed with an inverse Fourier tranform. The latter is obtained 
-again using the `FFTW` plans but now via `ldiv!`:
+Then the derivative in physical space, `∂ₓf`, is obtained with an inverse Fourier 
+tranform. The latter is obtained again using the `FFTW` plans but now via `ldiv!`:
 
 ```@example 1
 ldiv!(∂ₓf, grid.rfftplan, ∂ₓfh)
 
 plot(grid.x, [f ∂ₓf], label=["f" "∂f/∂x"], xlabel="x")
 
-savefig("assets/plot3.png"); nothing # hide
+savefig("assets/plot3.svg"); nothing # hide
 ```
 
-![](assets/plot3.png)
+![](assets/plot3.svg)

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -24,7 +24,7 @@ OneDimensionalGrid
   ├────────── size Lx: 6.283185307179586
   ├──── resolution nx: 64
   ├── grid spacing dx: 0.09817477042468103
-  └────────── domain: x ∈ [-3.141592653589793, 3.0434178831651124]
+  └─────────── domain: x ∈ [-3.141592653589793, 3.0434178831651124]
 ```
 
 The grid domain is, by default, constructed symmetrically around $x=0$, but this 

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -27,8 +27,8 @@ OneDimensionalGrid
   └────────── domain: x ∈ [-3.141592653589793, 3.0434178831651124]
 ```
 
-The grid domain is, by default, constructed symmetrically around 0, but this can 
-be altered using the `x0` keyword argument of `OneDGrid` constructor. The grid 
+The grid domain is, by default, constructed symmetrically around $x=0$, but this 
+can be altered using the `x0` keyword argument of `OneDGrid` constructor. The grid 
 spacing is $L_x/n_x$. Note that the last point of the domain is a grid-spacing 
 before $L_x/2$. This is because periodicity implies that the value of any field 
 at the end-points of the domain are equal and, therefore, grid-point values at

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -1,5 +1,114 @@
 # Grids
 
 
-We support 1D, 2D, and 3D grids.
+1D, 2D, and 3D grids are supported.
 
+A one-dimensional grid with $n_x = 64$ grid points and length $L_x = 2.0$ is constructed using
+
+```@meta
+DocTestSetup = quote
+    using FourierFlows
+end
+```
+
+```jldoctest
+julia> nx, Lx = 64, 2π
+julia> grid = OneDGrid(nx, Lx)
+OneDimensionalGrid
+                Device: CPU
+             FloatType: Float64
+               size Lx: 6.283185307179586
+         resolution nx: 64
+       grid spacing dx: 0.09817477042468103
+                domain: x ∈ [-3.141592653589793, 3.0434178831651124])```
+```
+
+The grid spacing is simply $L_x/n_x$. Note that $x\in [-L_x/2, L_x/2 - L_x/n_x]$ since periodicity
+implies that the value of any field at $x=L_x/2$ is the same as $x=-L_x/2$.
+
+We can define an array $f$ on this grid as
+
+```@setup 1
+using FourierFlows
+using LinearAlgebra: mul!, ldiv!
+using Plots # hide
+nx, Lx = 64, 2π
+grid = OneDGrid(nx, Lx)
+```
+
+
+```@example 1
+f = @. sin(2 * grid.x) + 1/2 * cos(5 * grid.x)
+nothing # hide
+```
+
+and plot it
+
+```@example 1
+plot(grid.x, f, label="f", xlabel="x")
+savefig("assets/plot1.png"); nothing # hide
+```
+
+![](assets/plot1.png)
+
+The Fourier transform of $f$ is $\hat{f}$. Since our `f` array is real-valued then we should use the `real-FFT` algorithm. The real-valued FFT transform only saves the Fourier coefficients for $k\ge 0$; the coefficients for negative wavenumbers can be obtained via $\hat{f}(-k) = \hat{f}(k)^\star$.
+
+The `grid` includes the `FFT` plans for both real-valued and complex valued transforms:
+
+```@example 1
+grid.fftplan
+```
+
+```@example 1
+grid.rfftplan
+```
+
+We use the convention that variables names with `h` at the end stand for variable-hat, i.e., $\hat{f}$  is the Fourier transform of $f$ and is stored in array `fh`.
+
+```@example 1
+fh = zeros(FourierFlows.cxeltype(grid), grid.nkr)
+
+mul!(fh, grid.rfftplan, f)
+
+plot(grid.kr, [real.(fh / nx), imag.(fh / nx)],
+          label = ["real\\( rfft\\(f\\) \\)" "imag\\( rfft\\(f\\) \\)"],
+         xlabel = "k",
+          xlims = (-0.5, 10.5),
+         marker = :auto)
+
+savefig("assets/plot2.png"); nothing # hide
+```
+
+![](assets/plot2.png)
+
+We can compute its derivative via Fourier transforms. To do that we can use the
+`FFTW` plans that are constructed with the grid. First we allocate an empty array
+where the values of the derivative will be stored,
+
+```@example 1
+∂ₓf = similar(f)
+∂ₓfh = similar(fh)
+
+nothing # hide
+```
+
+Array `∂ₓfh` is populated with $\mathrm{i} k \hat{f}$
+
+```@example 1
+@. ∂ₓfh = im * grid.kr * fh
+
+nothing # hide
+```
+
+Then `∂ₓf` is computed with an inverse Fourier tranform. The latter is obtained 
+again using the `FFTW` plans but now via `ldiv!`:
+
+```@example 1
+ldiv!(∂ₓf, grid.rfftplan, ∂ₓfh)
+
+plot(grid.x, [f ∂ₓf], label=["f" "∂f/∂x"], xlabel="x")
+
+savefig("assets/plot3.png"); nothing # hide
+```
+
+![](assets/plot3.png)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -16,8 +16,8 @@ Fourier-based pseudospectral methods. We support 1-, 2-, and 3-dimensional domai
 
 ## Examples
 
-For examples of `FourierFlows.jl` in action, see 
-[`GeophysicalFlows.jl`](https://github.com/FourierFlows/GeophysicalFlows.jl)
+For examples of `FourierFlows.jl` in action, see the child packages
+[`GeophysicalFlows.jl`](https://github.com/FourierFlows/GeophysicalFlows.jl) or [`PassiveTracerFlows.jl`](https://github.com/FourierFlows/PassiveTracerFlows.jl).
 
 ## Developers
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,14 +1,5 @@
 # FourierFlows.jl Documentation
 
-## Installation
-
-Install `FourierFlows.jl` from the `julia` `REPL` prompt with
-
-```julia
-using Pkg
-Pkg.add("FourierFlows")
-```
-
 ## Overview
 
 FourierFlows provides a framework to write solvers for partial differential equations on periodic domains with

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,7 +12,7 @@ Pkg.add("FourierFlows")
 ## Overview
 
 FourierFlows provides a framework to write solvers for partial differential equations on periodic domains with
-Fourier-based pseudospectral methods. We support 1-, 2-, and 3-dimensional domains.
+Fourier-based pseudospectral methods that run seamlessly on CPUs and GPUs. We support 1-, 2-, and 3-dimensional domains.
 
 ## Examples
 

--- a/docs/src/installation_instructions.md
+++ b/docs/src/installation_instructions.md
@@ -1,0 +1,16 @@
+# Installation instructions
+
+Install the latest version of FourierFlows using the built-in package manager (accessed by pressing `]` in the
+Julia command prompt)
+
+```julia
+julia>]
+(v1.4) pkg> add FourierFlows
+(v1.4) pkg> instantiate
+```
+
+You can update to the latest tagged release from the package manager via
+
+```julia
+(v1.4) pkg> update FourierFlows
+```

--- a/docs/src/installation_instructions.md
+++ b/docs/src/installation_instructions.md
@@ -1,4 +1,4 @@
-# Installation instructions
+# Installation Instructions
 
 Install the latest version of FourierFlows using the built-in package manager (accessed by pressing `]` in the
 Julia command prompt)

--- a/examples/OneDShallowWaterGeostrophicAdjustment.jl
+++ b/examples/OneDShallowWaterGeostrophicAdjustment.jl
@@ -12,9 +12,11 @@
 # The linearized equations for the evolution of $u$, $v$, $\eta$ are:
 #
 # ```math
-# \frac{\partial u}{\partial t} - f v = - g \frac{\partial \eta}{\partial x} - \mathrm{D} u, \\
-# \frac{\partial v}{\partial t} + f u = - \mathrm{D} v, \\
-# \frac{\partial \eta}{\partial t} + H \frac{\partial u}{\partial x} = - \mathrm{D} \eta.
+# \begin{aligned}
+# \frac{\partial u}{\partial t} - f v & = - g \frac{\partial \eta}{\partial x} - \mathrm{D} u, \\
+# \frac{\partial v}{\partial t} + f u & = - \mathrm{D} v, \\
+# \frac{\partial \eta}{\partial t} + H \frac{\partial u}{\partial x} & = - \mathrm{D} \eta.
+# \end{aligned}
 # ```
 #
 # Above, $g$ is the gravitational acceleration, $f$ is the  Coriolis parameter,
@@ -50,7 +52,7 @@ using Random
 # - `Equation` struct containining the coefficients of the linear operator $\mathcal{L}$ and the function that computes the nonlinear terms, usually named `calcN!()`.
 # 
 # The `Grid` structure is provided by FourierFlows.jl. One simply has to call one of
-# the `OneDGrid()`,  `TwoDGrid()`, or `ThreeDGrid()` grid constructors, depending
+# the `OneDGrid()`, `TwoDGrid()`, or `ThreeDGrid()` grid constructors, depending
 # on the dimensionality of the problem. All other structs mentioned above are problem-specific
 # and need to be constructed for every set of equations we want to solve.
 
@@ -97,9 +99,11 @@ nothing #hide
 # In Fourier space, the 1D linear shallow water dynamics are:
 #
 # ```math
-# \frac{\partial \hat{u}}{\partial t} = \underbrace{ f \hat{v} - \mathrm{i} k g \hat{\eta} }_{\mathcal{N}_u} \; \underbrace{- \nu |\boldsymbol{k}|^2 }_{\mathcal{L}_u} \hat{u}, \\
-# \frac{\partial \hat{v}}{\partial t} = \underbrace{ - f \hat{u} }_{\mathcal{N}_v} \; \underbrace{- \nu |\boldsymbol{k}|^2 }_{\mathcal{L}_v} \hat{v}, \\
-# \frac{\partial \hat{\eta}}{\partial t} = \underbrace{ - \mathrm{i} k H \hat{u} }_{\mathcal{N}_{\eta}} \; \underbrace{- \nu |\boldsymbol{k}|^2 }_{\mathcal{L}_{\eta}} \hat{\eta}.
+# \begin{aligned}
+# \frac{\partial \hat{u}}{\partial t} & = \underbrace{ f \hat{v} - \mathrm{i} k g \hat{\eta} }_{\mathcal{N}_u} \; \underbrace{- \nu |\boldsymbol{k}|^2 }_{\mathcal{L}_u} \hat{u}, \\
+# \frac{\partial \hat{v}}{\partial t} & = \underbrace{ - f \hat{u} }_{\mathcal{N}_v} \; \underbrace{- \nu |\boldsymbol{k}|^2 }_{\mathcal{L}_v} \hat{v}, \\
+# \frac{\partial \hat{\eta}}{\partial t} & = \underbrace{ - \mathrm{i} k H \hat{u} }_{\mathcal{N}_{\eta}} \; \underbrace{- \nu |\boldsymbol{k}|^2 }_{\mathcal{L}_{\eta}} \hat{\eta}.
+# \end{aligned}
 # ```
 # Although, e.g., terms involving the Coriolis accelaration are, in principle, 
 # linear we include them in the nonlinear term $\mathcal{N}$ because they render 

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -62,7 +62,7 @@ using
   CUDAapi,
   Requires
 
-import Base: resize!, getindex, setindex!, push!, append!
+import Base: resize!, getindex, setindex!, push!, append!, show
 
 using Base: fieldnames
 using FFTW: fftfreq, rfftfreq

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -25,11 +25,14 @@ function getaliasedwavenumbers(nk, nkr, aliasfraction)
 end
 
 """
-    OneDGrid(nx, Lx; x0=-Lx/2, nthreads=Sys.CPU_THREADS, effort=FFTW.MEASURE)
+    OneDGrid(nx, Lx; x0=-Lx/2, nthreads=Sys.CPU_THREADS, effort=FFTW.MEASURE, 
+                      T=Float64, dealias=1/3, ArrayType=Array)
 
 Constructs a OneDGrid object with size `Lx`, resolution `nx`, and leftmost
 position `x0`. FFT plans are generated for `nthreads` CPUs using
-FFTW flag `effort`.
+FFTW flag `effort`. The float type is `T` and the array types is `ArrayType`. 
+The `dealias` keyword determines the highest wavenubers that are being zero-ed
+out by `dealias()` function; 1/3 is the nominal value for quadratic nonlinearities. 
 """
 struct OneDGrid{T<:AbstractFloat, Tk, Tx, Tfft, Trfft} <: AbstractGrid{T, Tk}
         nx :: Int
@@ -92,7 +95,11 @@ end
 """
     TwoDGrid(nx, Lx, ny=nx, Ly=Lx; x0=-Lx/2, y0=-Ly/2, nthreads=Sys.CPU_THREADS, effort=FFTW.MEASURE)
 
-Constructs a TwoDGrid object.
+Constructs a TwoDGrid object with size `Lx`, `Ly`, resolution `nx`, `ny`, and leftmost
+positions `x0`, `y0`. FFT plans are generated for `nthreads` CPUs using
+FFTW flag `effort`. The float type is `T` and the array types is `ArrayType`. 
+The `dealias` keyword determines the highest wavenubers that are being zero-ed
+out by `dealias()` function; 1/3 is the nominal value for quadratic nonlinearities. 
 """
 struct TwoDGrid{T<:AbstractFloat, Tk, Tx, Tfft, Trfft} <: AbstractGrid{T, Tk}
         nx :: Int
@@ -172,9 +179,14 @@ function TwoDGrid(nx, Lx, ny=nx, Ly=Lx; x0=-Lx/2, y0=-Ly/2, nthreads=Sys.CPU_THR
 end
 
 """
-    ThreeDGrid(nx, Lx, ny=nx, Ly=Lx, nz=nx, Lz=Lx; x0=-Lx/2, y0=-Ly/2, z0=-Lz/2, nthreads=Sys.CPU_THREADS, effort=FFTW.MEASURE)
+    ThreeDGrid(nx, Lx, ny=nx, Ly=Lx, nz=nx, Lz=Lx; x0=-Lx/2, y0=-Ly/2, z0=-Lz/2, 
+    nthreads=Sys.CPU_THREADS, effort=FFTW.MEASURE, T=Float64, dealias=1/3, ArrayType=Array)
 
-Constructs a ThreeDGrid object.
+ Constructs a TwoDGrid object with size `Lx`, `Ly`, `Lz`, resolution `nx`, `ny`,
+ `nz` and leftmost positions `x0`, `y0`, `z0`. FFT plans are generated for `nthreads` 
+ CPUs using FFTW flag `effort`. The float type is `T` and the array types is `ArrayType`. 
+ The `dealias` keyword determines the highest wavenubers that are being zero-ed
+ out by `dealias()` function; 1/3 is the nominal value for quadratic nonlinearities. 
 """
 struct ThreeDGrid{T<:AbstractFloat, Tk, Tx, Tfft, Trfft} <: AbstractGrid{T, Tk}
         nx :: Int
@@ -366,7 +378,12 @@ end
 makefilter(g, T, sz; kwargs...) = ones(T, sz) .* makefilter(g; realvars=sz[1]==g.nkr, kwargs...)
 makefilter(eq; kwargs...) = makefilter(eq.grid, fltype(eq.T), eq.dims; kwargs...)
 
-griddevice(g::AbstractGrid{T, A}) where {T, A} = A<:Array ? "CPU" : "GPU"
+"""
+    griddevice(grid)
+
+Returns the device on which the `grid` lives on.
+"""
+griddevice(grid::AbstractGrid{T, A}) where {T, A} = A<:Array ? "CPU" : "GPU"
 
 show(io::IO, g::OneDGrid{T}) where {T, A} =
      print(io, "OneDimensionalGrid\n",

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -365,3 +365,35 @@ end
 
 makefilter(g, T, sz; kwargs...) = ones(T, sz) .* makefilter(g; realvars=sz[1]==g.nkr, kwargs...)
 makefilter(eq; kwargs...) = makefilter(eq.grid, fltype(eq.T), eq.dims; kwargs...)
+
+griddevice(g::AbstractGrid{T, A}) where {T, A} = A<:Array ? "CPU" : "GPU"
+
+show(io::IO, g::OneDGrid{T}) where {T, A} =
+     print(io, "OneDimensionalGrid\n",
+              "                Device: ", griddevice(g), '\n',
+              "             FloatType: $T", '\n', 
+              "               size Lx: ", g.Lx, '\n',
+              "         resolution nx: ", g.nx, '\n',
+              "       grid spacing dx: ", g.dx, '\n',
+              "                domain: x ∈ [$(g.x[1]), $(g.x[end])])")
+
+show(io::IO, g::TwoDGrid{T}) where {T, A} =
+     print(io, "TwoDimensionalGrid\n",
+               "                   Device: ", griddevice(g), '\n',
+               "                FloatType: $T", '\n', 
+               "            size (Lx, Ly): ", (g.Lx, g.Ly), '\n',
+               "      resolution (nx, ny): ", (g.nx, g.ny), '\n',
+               "    grid spacing (dx, dy): ", (g.dx, g.dy), '\n',
+               "                   domain: x ∈ [$(g.x[1]), $(g.x[end])])", '\n',
+               "                           y ∈ [$(g.y[1]), $(g.y[end])])")
+
+show(io::IO, g::ThreeDGrid{T}) where {T, A} =
+     print(io, "ThreeDimensionalGrid\n",
+               "                       Device: ", griddevice(g), '\n',
+               "                    FloatType: $T", '\n', 
+               "            size (Lx, Ly, Lz): ", (g.Lx, g.Ly, g.Ly), '\n',
+               "      resolution (nx, ny, nz): ", (g.nx, g.ny, g.nz), '\n',
+               "    grid spacing (dx, dy, dz): ", (g.dx, g.dy, g.dz), '\n',
+               "                       domain: x ∈ [$(g.x[1]), $(g.x[end])])", '\n',
+               "                               y ∈ [$(g.y[1]), $(g.y[end])])", '\n',
+               "                               z ∈ [$(g.z[1]), $(g.z[end])])")

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -406,16 +406,16 @@ Returns the device on which the `grid` lives on.
 """
 griddevice(grid::AbstractGrid{T, A}) where {T, A} = A<:Array ? "CPU" : "GPU"
 
-show(io::IO, g::OneDGrid{T}) where {T, A} =
+show(io::IO, g::OneDGrid{T}) where T =
      print(io, "OneDimensionalGrid\n",
                "  ├─────────── Device: ", griddevice(g), '\n',
                "  ├──────── FloatType: $T", '\n', 
                "  ├────────── size Lx: ", g.Lx, '\n',
                "  ├──── resolution nx: ", g.nx, '\n',
                "  ├── grid spacing dx: ", g.dx, '\n',
-               "  └────────── domain: x ∈ [$(g.x[1]), $(g.x[end])]")
+               "  └─────────── domain: x ∈ [$(g.x[1]), $(g.x[end])]")
 
-show(io::IO, g::TwoDGrid{T}) where {T, A} =
+show(io::IO, g::TwoDGrid{T}) where T =
      print(io, "TwoDimensionalGrid\n",
                "  ├───────────────── Device: ", griddevice(g), '\n',
                "  ├────────────── FloatType: $T", '\n', 
@@ -425,7 +425,7 @@ show(io::IO, g::TwoDGrid{T}) where {T, A} =
                "  └───────────────── domain: x ∈ [$(g.x[1]), $(g.x[end])]", '\n',
                "                             y ∈ [$(g.y[1]), $(g.y[end])]")
 
-show(io::IO, g::ThreeDGrid{T}) where {T, A} =
+show(io::IO, g::ThreeDGrid{T}) where T =
      print(io, "ThreeDimensionalGrid\n",
                "  ├───────────────────── Device: ", griddevice(g), '\n',
                "  ├────────────────── FloatType: $T", '\n', 

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -1,3 +1,11 @@
+"""
+    Equation{T, TL, G<:AbstractFloat}
+    
+A struct that includes the equation to be solved `∂u/∂t = L*u + N(u)`. Array `L` 
+includes the coefficients of the linear term `L*u` and `calcN!` is a function 
+which computes the nonlinear term `N(u)`. The struct also includes the problem's
+`grid` and the float type of the state vector (and consequently of `N(u)`).
+"""
 struct Equation{T, TL, G<:AbstractFloat}
        L :: TL
   calcN! :: Function
@@ -6,11 +14,23 @@ struct Equation{T, TL, G<:AbstractFloat}
        T :: T # eltype or tuple of eltypes of sol and N
 end
 
+"""
+    Equation(L, calcN!, grid; dims=supersize(L), T=nothing)
+    
+An equation constructor given the array `L` of the coefficients of the linear
+term, the function `calcN!` that computes the nonlinear term and the problem's 
+`grid`.
+"""
 function Equation(L, calcN!, grid::AbstractGrid{G}; dims=supersize(L), T=nothing) where G
   T = T == nothing ? T = cxtype(G) : T
   Equation(L, calcN!, grid, dims, T)
 end
 
+"""
+    Clock{T<:AbstractFloat}
+    
+A struct containing the time-step `dt`, the time `t` and the `step`-number of the simulation.
+"""
 mutable struct Clock{T<:AbstractFloat}
     dt :: T
      t :: T
@@ -18,10 +38,11 @@ mutable struct Clock{T<:AbstractFloat}
 end
 
 """
-    Problem(sol, clock, grid, eqn, vars, params, timestepper)
-
-Initialize a FourierFlows problem on grid g, with variables v, parameters p,
-equation eq, and timestepper ts.
+    Problem{T, A<:AbstractArray, Tg<:AbstractFloat, TL}
+    
+A struct including everything a FourierFlows problem requires: the state vector
+`sol`, the `clock`, the equation `eqn`, the `grid`, all problem variables in 
+`vars`, problem parameters in `params`, and the `timestepper`.
 """
 struct Problem{T, A<:AbstractArray, Tg<:AbstractFloat, TL}
           sol :: A
@@ -33,19 +54,31 @@ struct Problem{T, A<:AbstractArray, Tg<:AbstractFloat, TL}
   timestepper :: AbstractTimeStepper{A}
 end
 
+"""
+    EmptyParams <: AbstractParams
+
+A placeholder struct for parameters.
+"""
 struct EmptyParams <: AbstractParams end
+
+"""
+    EmptyVars <: AbstractVars
+
+A placeholder struct for variables.
+"""
 struct EmptyVars <: AbstractVars end
 
 """
     Problem(eqn::Equation, stepper, dt, grid::AbstractGrid,
             vars=EmptyVars, params=EmptyParams, dev::Device=CPU(); stepperkwargs...)
 
-Construct a `Problem` for `eqn` using the time`stepper` with timestep `dt`, on `grid` and 
-`dev`ice and with optional `vars`, and `params`. The `stepperkwargs` are passed to the time-stepper
+Construct a `Problem` for equation `eqn` using the time`stepper` with timestep 
+`dt`, on `grid` and `dev`ice. Optionally provide variables in `vars` and
+parameters with `params`. The `stepperkwargs` are passed to the time-stepper
 constructor.
 """
-function Problem(eqn::Equation, stepper, dt, grid::AbstractGrid{T, A}, 
-                 vars=EmptyVars, params=EmptyParams, dev::Device=CPU(); stepperkwargs...) where {T, A}
+function Problem(eqn::Equation, stepper, dt, grid::AbstractGrid{T}, 
+                 vars=EmptyVars, params=EmptyParams, dev::Device=CPU(); stepperkwargs...) where T
                  
   clock = Clock{T}(dt, 0, 0)
 
@@ -55,4 +88,3 @@ function Problem(eqn::Equation, stepper, dt, grid::AbstractGrid{T, A},
 
   return Problem(sol, clock, eqn, grid, vars, params, timestepper)
 end
-


### PR DESCRIPTION
This PR:

- Adds `Grids` sections in Docs where we explain how grids are constructed and how fftplans can be used to perform forward and inverse Fourier transforms.
- Overloads `Base.show` for `AbstractGrids` based on the template used in `Oceananigans.jl`
- Fixes `Forcing` section in Docs to be compliant with Documenter.jl's KaTeX LaTeX interpreter; forcing section should be moved elsewhere since it's more relevant to particular modules in GeophysicalFlows.jl
- Updates many docstrings in `domains.jl` and `problem.jl`.