### PR TITLE
Using CUDA.jl

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 variables:
   CI_IMAGE_TAG: 'cuda'
-  JULIA_NUM_THREADS: '1'
+  JULIA_NUM_THREADS: '4'
   JULIA_CUDA_VERBOSE: 'true'
   JULIA_CUDA_USE_BINARYBUILDER: 'false' # reduce CI network traffic
 
@@ -17,6 +17,12 @@ julia:1.4:
     - nvidia
   variables:
     CI_THOROUGH: 'true'
+
+julia:1.5:
+  extends:
+    - .julia:1.5
+    - .test
+  allow_failure: true
 
 test:nightly:
   extends:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 
 julia:
   - 1.4
+  - 1.5
   - nightly
 
 jobs:

--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,7 @@ repository = "https://github.com/FourierFlows/FourierFlows.jl"
 version = "0.5.2"
 
 [deps]
-CUDAapi = "3895d2a7-ec45-59b8-82bb-cfc6a382f9b3"
-CuArrays = "3a865a2d-5b23-5a0f-bc46-62713ec82fae"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
@@ -18,18 +17,15 @@ JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-CUDAapi = "^2, ^4"
-CuArrays = "^1, ^2"
+CUDA = "^1"
 DocStringExtensions = "^0.8"
 FFTW = "^1"
 Interpolations = "^0.12"
 JLD2 = "^0.1"
 Reexport = "^0.2"
-Requires = "^1"
 julia = "^1.4"
 
 [extras]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.4
+  - julia_version: 1.5
   - julia_version: nightly
 
 platform:

--- a/src/CuFourierFlows.jl
+++ b/src/CuFourierFlows.jl
@@ -1,5 +1,3 @@
-using .CuArrays
-
 # Discard `effort` argument for CuArrays
 plan_flows_fft(a::CuArray, args...; flags=nothing, kwargs...) = plan_fft(a, args...; kwargs...)
 plan_flows_rfft(a::CuArray, args...; flags=nothing, kwargs...) = plan_rfft(a, args...; kwargs...)

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -111,7 +111,6 @@ include("timesteppers.jl")
 # Physics
 include("diffusion.jl")
 
-
 """
     @has_cuda expr
 A macro to compile and execute `expr` only if CUDA is installed and available. Generally 
@@ -122,6 +121,8 @@ macro has_cuda(expr)
   return has_cuda() ? :($(esc(expr))) : :(nothing)
 end
 
+# CUDA functionality
+@has_cuda include("CuFourierFlows.jl")
 
 function __init__()
   
@@ -138,8 +139,6 @@ function __init__()
     end
 
     CUDA.allowscalar(false)
-    
-    include("CuFourierFlows.jl")
   end
 end
 

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -111,15 +111,6 @@ include("timesteppers.jl")
 # Physics
 include("diffusion.jl")
 
-if has_cuda()
-  try
-    include("CuFourierFlows.jl")
-  catch ex
-    # something is wrong with the user's set-up (or there's a bug in CuArrays)
-    @warn "CUDA is installed, but CuArrays.jl fails to load" exception=(ex, catch_backtrace())
-  end
-end
-
 
 """
     @has_cuda expr
@@ -147,6 +138,8 @@ function __init__()
     end
 
     CUDA.allowscalar(false)
+    
+    include("CuFourierFlows.jl")
   end
 end
 

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -113,9 +113,7 @@ include("diffusion.jl")
 
 """
     @has_cuda expr
-A macro to compile and execute `expr` only if CUDA is installed and available. Generally 
-used to wrap expressions that can only be compiled if `CuArrays` and `CUDAnative` can be
-loaded.
+A macro to compile and execute `expr` only if CUDA is installed and available.
 """
 macro has_cuda(expr)
   return has_cuda() ? :($(esc(expr))) : :(nothing)
@@ -125,7 +123,6 @@ end
 @has_cuda include("CuFourierFlows.jl")
 
 function __init__()
-  
   threads = Threads.nthreads()
   if threads > 1
     @info "FourierFlows will use $threads threads"

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -59,8 +59,8 @@ function OneDGrid(nx, Lx; x0=-Lx/2, nthreads=Sys.CPU_THREADS, effort=FFTW.MEASUR
 
    invksq = @. 1 / k^2
   invkrsq = @. 1 / kr^2
-   invksq[1] = 0
-  invkrsq[1] = 0
+  CUDA.@allowscalar  invksq[1] = 0
+  CUDA.@allowscalar invkrsq[1] = 0
 
   FFTW.set_num_threads(nthreads)
    fftplan = plan_flows_fft(ArrayType{Complex{T}, 1}(undef, nx), flags=effort)
@@ -141,11 +141,11 @@ function TwoDGrid(nx, Lx, ny=nx, Ly=Lx; x0=-Lx/2, y0=-Ly/2, nthreads=Sys.CPU_THR
 
      Ksq = @. k^2 + l^2
   invKsq = @. 1 / Ksq
-  invKsq[1, 1] = 0
+  CUDA.@allowscalar invKsq[1, 1] = 0
 
      Krsq = @. kr^2 + l^2
   invKrsq = @. 1 / Krsq
-  invKrsq[1, 1] = 0
+  CUDA.@allowscalar invKrsq[1, 1] = 0
 
   # FFT plans
   FFTW.set_num_threads(nthreads)
@@ -240,11 +240,11 @@ function ThreeDGrid(nx, Lx, ny=nx, Ly=Lx, nz=nx, Lz=Lx; x0=-Lx/2, y0=-Ly/2, z0=-
 
      Ksq = @. k^2 + l^2 + m^2
   invKsq = @. 1 / Ksq
-  invKsq[1, 1, 1] = 0
+  CUDA.@allowscalar invKsq[1, 1, 1] = 0
 
      Krsq = @. kr^2 + l^2 + m^2
   invKrsq = @. 1 / Krsq
-  invKrsq[1, 1, 1] = 0
+  CUDA.@allowscalar invKrsq[1, 1, 1] = 0
 
   # FFT plans
   FFTW.set_num_threads(nthreads)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -159,12 +159,12 @@ end
 
 function parsevalsum2(uh, g::OneDGrid)
   if size(uh, 1) == g.nkr # uh is conjugate symmetric
-    U = sum(abs2, uh[1])                  # k=0 modes
-    U += @views 2*sum(abs2, uh[2:end])    # sum k>0 modes twice
+    U = sum(abs2, CUDA.@allowscalar uh[1])   # k=0 modes
+    U += @views 2*sum(abs2, uh[2:end])       # sum k>0 modes twice
   else # count every mode once
     U = sum(abs2, uh)
   end
-  norm = g.Lx/g.nx^2 # normalization for dft
+  norm = g.Lx / g.nx^2 # normalization for dft
   norm*U
 end
 
@@ -181,40 +181,40 @@ function parsevalsum(uh, g::TwoDGrid)
     U = sum(uh)
   end
 
-  norm = g.Lx*g.Ly/(g.nx^2*g.ny^2) # weird normalization for dft
+  norm = g.Lx * g.Ly / (g.nx^2 * g.ny^2) # weird normalization for dft
   norm*real(U)
 end
 
 """
-    jacobianh(a, b, g)
+    jacobianh(a, b, grid)
 
-Returns the transform of the Jacobian of two fields a, b on the grid g.
+Returns the Fourier transform of the Jacobian of `a` and `b` on `grid`.
 """
-function jacobianh(a, b, g::TwoDGrid)
+function jacobianh(a, b, grid::TwoDGrid)
   if eltype(a) <: Real
     bh = rfft(b)
-    bx = irfft(im*g.kr.*bh, g.nx)
-    by = irfft(im*g.l.*bh, g.nx)
-    return im*g.kr.*rfft(a.*by)-im*g.l.*rfft(a.*bx)
+    bx = irfft(im * grid.kr .* bh, grid.nx)
+    by = irfft(im * grid.l  .* bh, grid.nx)
+    return im * grid.kr .* rfft(a .* by) .- im * grid.l .* rfft(a .* bx)
   else
-    # J(a, b) = dx(a b_y) - dy(a b_x)
+    # J(a, b) = ∂(a * ∂b/∂y)/∂x - ∂(a * ∂b/∂x)/∂y
     bh = fft(b)
-    bx = ifft(im*g.k.*bh)
-    by = ifft(im*g.l.*bh)
-    return im*g.k.*fft(a.*by).-im*g.l.*fft(a.*bx)
+    bx = ifft(im * grid.k .* bh)
+    by = ifft(im * grid.l .* bh)
+    return im * grid.k .* fft(a .* by) .- im * grid.l .* fft(a .* bx)
   end
 end
 
 """
-    jacobian(a, b, g)
+    jacobian(a, b, grid)
 
-Returns the Jacobian of a and b.
+Returns the Jacobian of `a` and `b` on `grid`.
 """
-function jacobian(a, b, g::TwoDGrid)
+function jacobian(a, b, grid::TwoDGrid)
   if eltype(a) <: Real
-   return irfft(jacobianh(a, b, g), g.nx)
+   return irfft(jacobianh(a, b, grid), grid.nx)
   else
-   return ifft(jacobianh(a, b, g))
+   return ifft(jacobianh(a, b, grid))
   end
 end
 
@@ -272,7 +272,7 @@ function radialspectrum(ah, g::TwoDGrid; n=nothing, m=nothing, refinement=2)
     ahρ =  ρ.*sum(ahρθ, dims=2)*dθ
   end
 
-  ahρ[1] = ah[1, 1] # zeroth mode
+  CUDA.@allowscalar ahρ[1] = ah[1, 1] # zeroth mode
 
   ρ, ahρ
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,14 @@
 using
-  FourierFlows,
-  FourierFlows.Diffusion,
   FFTW,
   LinearAlgebra,
   Printf,
   JLD2,
+  CUDA,
   Test
+
+using
+  FourierFlows,
+  FourierFlows.Diffusion
 
 using FourierFlows: parsevalsum2
 
@@ -14,7 +17,6 @@ using LinearAlgebra: mul!, ldiv!, norm
 # the devices on which tests will run
 devices = (CPU(),)
 @has_cuda devices = (CPU(), GPU())
-@has_cuda using CuArrays
 
 const rtol_fft = 1e-12
 const rtol_output = 1e-12
@@ -37,7 +39,7 @@ include("createffttestfunctions.jl")
 
 for dev in devices
   
-  println("testing on "*string(typeof(dev)))
+  println("testing on " * string(typeof(dev)))
 
   @time @testset "Grid tests" begin
     include("test_grid.jl")

--- a/test/test_instantiate_problem.jl
+++ b/test/test_instantiate_problem.jl
@@ -18,5 +18,5 @@ function instantiate_problem_with_filter_kwargs(dev, stepper)
 
     stepper = real_problem.timestepper
     
-    return stepper.filter[3] < 1e-16
+    return CUDA.@allowscalar stepper.filter[3] < 1e-16
 end

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -36,7 +36,7 @@ function test_getindex(dev::Device=CPU())
   filename = joinpath(".", "testoutput.jld2")
   
   ctest = devzeros(dev, Float64, (prob.grid.nx, ))
-  ctest[3] = π
+  CUDA.@allowscalar ctest[3] = π
   prob.vars.c .= ctest
   
   get_c(prob) = prob.vars.c
@@ -52,7 +52,7 @@ function test_saveproblem_saveoutput(dev::Device=CPU())
   if isfile(filename); rm(filename); end
   
   ctest = devzeros(dev, Float64, (prob.grid.nx, ))
-  ctest[3] = π
+  CUDA.@allowscalar ctest[3] = π
   prob.vars.c .= ctest
   
   get_c(prob) = collect(prob.vars.c)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -52,15 +52,15 @@ end
 
 # This test could use some further work.
 function test_radialspectrum(dev::Device, n, ahkl, ahρ; debug=false, atol=0.1, rfft=false)
-  g = TwoDGrid(dev, n, 2π)
+  grid = TwoDGrid(dev, n, 2π)
   if rfft==true
-    ah = @. ahkl(g.kr, g.l)
+    ah = @. ahkl(grid.kr, grid.l)
   else   
-    ah = @. ahkl(g.k, g.l)
+    ah = @. ahkl(grid.k, grid.l)
   end
   CUDA.@allowscalar ah[1, 1] = 0.0
 
-  ρ, ahρ_estimate = FourierFlows.radialspectrum(ah, g; refinement=16)
+  ρ, ahρ_estimate = FourierFlows.radialspectrum(ah, grid; refinement=16)
 
   if debug
     println(sum(ahρ.(ρ) - ahρ_estimate))

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -58,7 +58,7 @@ function test_radialspectrum(dev::Device, n, ahkl, ahρ; debug=false, atol=0.1, 
   else   
     ah = @. ahkl(g.k, g.l)
   end
-  ah[1, 1] = 0.0
+  CUDA.@allowscalar ah[1, 1] = 0.0
 
   ρ, ahρ_estimate = FourierFlows.radialspectrum(ah, g; refinement=16)
 


### PR DESCRIPTION
- Drops CuArrays.jl and CUDAapi.jl and uses CUDA.jl instead
- Disallows scalar operations on GPU

Closes #180 