### PR TITLE
Simplify notation in docs + adds note for unicode symbols

### DIFF
--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -5,22 +5,22 @@
 The code solves partial differential equations of the form
 
 ```math
- \partial_t u = \mathcal{L}u + \mathcal{N}(u)\ ,
+ \partial_t u = Lu + N(u)\ ,
 ```
 using Fourier transforms on periodic domains. Above, ``u(\bm{x}, t)`` is the state variable. 
-On the right-hand-side, term ``\mathcal{L} u`` is the 'linear' part of the equation. The term 
-``\mathcal{N}(u)`` is, in general, a 'nonlinear' part.
+On the right-hand-side, term ``L u`` is the 'linear' part of the equation. The term 
+``N(u)`` is, in general, a 'nonlinear' part.
 
-In FourierFlows.jl, ``\mathcal{L} u`` is specified by the various modules by prescribing the
-linear operator ``\mathcal{L}`` as an array of the same dimension as ``u``. The nonlinear term 
-``\mathcal{N}(u)`` is specified via a function that takes ``u`` as its argument.
+In FourierFlows.jl, ``L u`` is specified by the various modules by prescribing the
+linear operator ``L`` as an array of the same dimension as ``u``. The nonlinear term 
+``N(u)`` is specified via a function that takes ``u`` as its argument.
 
 Boundary conditions in all spatial dimensions are periodic. That allows us to expand all 
 variables using a Fourier decomposition. For example, if ``u`` depends only in one spatial 
 dimension, ``x``, defined over the domain ``x \in [0, L_x]``, then:
 
 ```math
-u(x, t) = \sum_{k_x} \hat{u}(k_x, t) \, \mathrm{e}^{\mathrm{i} k_x x} \ ,
+u(x, t) = \sum_{k_x} \hat{u}(k_x, t) \, e^{i k_x x} \ ,
 ```
 
 where wavenumbers ``k_x`` take the values ``\tfrac{2\pi}{L_x}\{0,\pm 1,\pm 2,\dots\}``. When we 
@@ -29,7 +29,7 @@ further consider that ``x`` takes discrete values over ``[0, L_x]``, e.g., ``x_j
 Fourier sum above truncates to:
 
 ```math
-u_j(t) = \sum_{k=-n_x/2}^{n_x/2-1} \hat{u}_k(t)\,\mathrm{e}^{2\pi \mathrm{i} k x_j / L_x}\ .
+u_j(t) = \sum_{k=-n_x/2}^{n_x/2-1} \hat{u}_k(t)\,e^{2\pi i k x_j / L_x}\ .
 ```
 
 (Above we assumed that ``n_x`` is even.)
@@ -37,10 +37,10 @@ u_j(t) = \sum_{k=-n_x/2}^{n_x/2-1} \hat{u}_k(t)\,\mathrm{e}^{2\pi \mathrm{i} k x
 Applying the Fourier transform as above, the partial differential equation transforms to:
 
 ```math
- \partial_t \hat{u} = \hat{\mathcal{L}} \hat{u} + \widehat{ \mathcal{N}(u) }\ ,
+ \partial_t \hat{u} = \hat{L} \hat{u} + \widehat{ N(u) }\ ,
 ```
 
-where ``\hat{\mathcal{L}}`` above denotes the linear operator in Fourier space.
+where ``\hat{L}`` above denotes the linear operator in Fourier space.
 
 Equations are oftentimes time-stepped forward in Fourier space. Doing so, ``\hat{u}_k(t)`` 
 becomes our state variable, i.e., the array with all Fourier coefficients of the solution 

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -32,7 +32,7 @@ OneDimensionalGrid
 The grid domain is, by default, constructed symmetrically around ``x = 0``, but this 
 can be altered using the `x0` keyword argument of `OneDGrid` constructor. The grid 
 spacing is ``L_x / n_x``. Note that the last point of the domain is a grid-spacing 
-before ``L_x/2``. This is because periodicity implies that the value of any field 
+before ``L_x / 2``. This is because periodicity implies that the value of any field 
 at the end-points of the domain are equal and, therefore, grid-point values at
 both these end-points are reduntant.
 
@@ -68,7 +68,7 @@ savefig("assets/plot1.svg"); nothing # hide
 Function ``u(x)`` can be expanded in Fourier series:
 
 ```math
-u(x) = \sum_{k} \hat{u}(k)\,e^{i k x},
+u(x) = \sum_{k} \hat{u}(k) \, e^{i k x} ,
 ```
 
 where ``\hat{u}(k)`` is Fourier transform of ``u(x)`` and ``k`` the discrete set of 
@@ -76,17 +76,16 @@ wavenumbers that fit within our finite domain. We can compute ``\hat{u}`` via a
 Fast Fourier Transform (FFT). Since our `u` array is real-valued then we should 
 use the `real-FFT` algorithm. The real-valued FFT transform only saves the Fourier 
 coefficients for ``k \ge 0``; the coefficients for negative wavenumbers can be 
-.
+obtained via ``\hat{u}(-k) = \hat{u}(k)^{*}``.
 
-
-The wavenumbers used in FFT are contained in `grid.k` ordered as:
+The wavenumbers used in FFT are contained in `grid.k` and they are ordered as:
 ```math
-\frac{2\pi}{L_x}\{0, 1, \dots, n_x/2-1, -n_x/2, -n_x/2+1, \dots, -1\},
+\frac{2\pi}{L_x} \{ 0, 1, \dots, n_x/2-1, -n_x/2, -n_x/2+1, \dots, -1 \} ,
 ```
-while the wavenumbers for real FFT are in `grid.kr` as:
+while the wavenumbers for real FFT are in `grid.kr`:
 
 ```math
-\frac{2\pi}{L_x}\{0, 1, \dots, n_x/2-1\}.
+\frac{2\pi}{L_x} \{ 0, 1, \dots, n_x/2-1 \} .
 ```
 
 

--- a/docs/src/grids.md
+++ b/docs/src/grids.md
@@ -5,7 +5,7 @@
 one-dimensional grid and how one can use it to perform Fourier transforms and 
 compute spatial derivatives.
 
-A one-dimensional grid with $n_x = 64$ grid points and length $L_x = 2\pi$ is 
+A one-dimensional grid with ``n_x = 64`` grid points and length ``L_x = 2 \pi`` is 
 constructed by
 
 ```@meta
@@ -29,14 +29,14 @@ OneDimensionalGrid
   └─────────── domain: x ∈ [-3.141592653589793, 3.0434178831651124]
 ```
 
-The grid domain is, by default, constructed symmetrically around $x=0$, but this 
+The grid domain is, by default, constructed symmetrically around ``x = 0``, but this 
 can be altered using the `x0` keyword argument of `OneDGrid` constructor. The grid 
-spacing is $L_x/n_x$. Note that the last point of the domain is a grid-spacing 
-before $L_x/2$. This is because periodicity implies that the value of any field 
+spacing is ``L_x / n_x``. Note that the last point of the domain is a grid-spacing 
+before ``L_x/2``. This is because periodicity implies that the value of any field 
 at the end-points of the domain are equal and, therefore, grid-point values at
 both these end-points are reduntant.
 
-We can define an array `u` that contains the values of a function $u(x)$ on this 
+We can define an array `u` that contains the values of a function ``u(x)`` on this 
 grid as
 
 ```@setup 1
@@ -65,18 +65,18 @@ savefig("assets/plot1.svg"); nothing # hide
 
 ![](assets/plot1.svg)
 
-Function $u(x)$ can be expanded in Fourier series:
+Function ``u(x)`` can be expanded in Fourier series:
 
 ```math
-u(x) = \sum_{k} \hat{u}(k)\,\mathrm{e}^{\mathrm{i} k x},
+u(x) = \sum_{k} \hat{u}(k)\,e^{i k x},
 ```
 
-where $\hat{u}(k)$ is Fourier transform of $u(x)$ and $k$ the discrete set of 
-wavenumbers that fit within our finite domain. We can compute $\hat{u}$ via a 
+where ``\hat{u}(k)`` is Fourier transform of ``u(x)`` and ``k`` the discrete set of 
+wavenumbers that fit within our finite domain. We can compute ``\hat{u}`` via a 
 Fast Fourier Transform (FFT). Since our `u` array is real-valued then we should 
 use the `real-FFT` algorithm. The real-valued FFT transform only saves the Fourier 
-coefficients for $k\ge 0$; the coefficients for negative wavenumbers can be 
-obtained via $\hat{u}(-k) = \hat{u}(k)^{*}$.
+coefficients for ``k \ge 0``; the coefficients for negative wavenumbers can be 
+.
 
 
 The wavenumbers used in FFT are contained in `grid.k` ordered as:
@@ -100,7 +100,9 @@ grid.fftplan
 grid.rfftplan
 ```
 
-We use the convention that variables names with `h` at the end stand for variable-hat, i.e., $\hat{u}$  is the Fourier transform of $u$ and is stored in array `uh`. Since `u` is of size $n_x$, the real-Fourier transform should be of size $n_{kr} = n_x/2+1$.
+We use the convention that variables names with `h` at the end stand for variable-hat, i.e., 
+``\hat{u}``  is the Fourier transform of ``u`` and is stored in array `uh`. Since `u` is of 
+size ``n_x``, the real-Fourier transform should be of size ``n_{kr} = n_x/2+1``.
 
 ```@example 1
 uh = Complex.(zeros(grid.nkr))
@@ -118,10 +120,10 @@ mul!(uh, grid.rfftplan, u)
 nothing # hide
 ```
 
-The `FFT` algorithm does not output exactly the Fourier coefficients $\hat{u}(k)$ but
-rather due to different normalization, `FFT` outputs something proportional to $\hat{u}(k)$. 
-To obtain $\hat{u}$ we need to divide the `FFT` output by the length of the 
-original array and by $\mathrm{e}^{-\mathrm{i} k x_0}$, where $x_0$ is the first 
+The `FFT` algorithm does not output exactly the Fourier coefficients ``\hat{u}(k)`` but
+rather due to different normalization, `FFT` outputs something proportional to ``\hat{u}(k)``. 
+To obtain ``\hat{u}`` we need to divide the `FFT` output by the length of the 
+original array and by ``e^{-i k x_0}``, where ``x_0`` is the first 
 point of our domain array.
 
 ```@example 1
@@ -150,7 +152,7 @@ nothing # hide
 ```
 
 The grid contains the wavenumbers (both for real-value functions `grid.kr` and 
-for complex-valued functions `grid.k`). We populate array `∂ₓuh` is with $\mathrm{i} k \hat{u}$:
+for complex-valued functions `grid.k`). We populate array `∂ₓuh` is with ``i k \hat{u}``:
 
 ```@example 1
 @. ∂ₓuh = im * grid.kr * uh

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,6 +15,12 @@ in the [Examples](generated/OneDShallowWaterGeostrophicAdjustment/) section of t
 For more examples of `FourierFlows.jl` in action, see the child packages
 [`GeophysicalFlows.jl`](https://github.com/FourierFlows/GeophysicalFlows.jl) or [`PassiveTracerFlows.jl`](https://github.com/FourierFlows/PassiveTracerFlows.jl).
 
+!!! info "Unicode"
+    Oftentimes unicode symbols appear in modules for variables or parameters. For example,
+    `κ` appears as the diffusivity in the `Diffusion` module. Unicode symbols can be entered 
+    in the Julia REPL by typing, e.g., `\kappa` followed by `tab` key. Read more about Unicode 
+    symbols in the [Julia Documentation](https://docs.julialang.org/en/v1/manual/unicode-input/).
+
 ## Developers
 
 FourierFlows is currently being developed by [Gregory L. Wagner](https://glwagner.github.io) and 

--- a/docs/src/problem.md
+++ b/docs/src/problem.md
@@ -7,8 +7,8 @@ Plots.scalefontsizes(1.25)
 Plots.default(lw=2)
 ```
 
-Everything needed to solve a PDE in `FourierFlows.jl` is gathered in a `Problem` 
-struct. The `Problem` struct contains various other structs, namely:
+Everything needed to solve a PDE in `FourierFlows.jl` is gathered in a `Problem` struct. T
+he `Problem` struct contains various other structs, namely:
 
 - grid (`grid`),
 - parameters (`params`),
@@ -18,14 +18,14 @@ struct. The `Problem` struct contains various other structs, namely:
 - clock (`clock`), and
 - state vector (`sol`).
 
-Here, we demonstrate we can construct such a `Problem` struct to solve the 1D
+Here, we demonstrate how we can construct such a `Problem` struct to solve the simple 1D 
 equation:
 
 ```math
 \partial_t u(x, t) = - \alpha \, u(x, t) ,
 ```
 
-on domain $x \in [-1, 1]$.
+on domain ``x \in [-1, 1]``.
 
 First, we construct our grid
 
@@ -37,7 +37,7 @@ nx, Lx = 32, 2.0
 grid = OneDGrid(nx, Lx)
 ```
 
-Our problem has a parameter $\alpha$. We create a `Params` struct by:
+Our problem has a parameter ``\alpha``. We create a `Params` struct by:
 
 ```@example 2
 struct Params <: AbstractParams
@@ -45,8 +45,8 @@ struct Params <: AbstractParams
 end
 ```
 
-and then we use the `struct`'s constructor to populate our struct with the 
-parameter value, e.g., $\alpha=0.1$:
+and then we use the `struct`'s constructor to populate our struct with the parameter value, 
+e.g., ``\alpha = 0.1``:
 
 ```@example 2
 α = 0.1
@@ -54,17 +54,16 @@ parameter value, e.g., $\alpha=0.1$:
 params = Params(α)
 ```
 
-The particular equation is so simple that it makes no difference 
-performance-wise whether we time-step it in physical or in wavenumber space. 
-For, PDEs with nonlinear terms time-stepping in wavenumbers spaces is much more
-efficient. Thus, for demonstration purposes, we will time-step the equation in 
-wavenumber space, i.e.,
+The particular equation is so simple that it makes no difference performance-wise whether 
+we time-step it in physical or in wavenumber space. For, PDEs with nonlinear terms 
+time-stepping in wavenumbers spaces is much more efficient. Thus, for demonstration purposes, 
+we will time-step the equation in wavenumber space, i.e.,
 
 ```math
 \partial_t \hat{u}(k, t) = - \alpha \, \hat{u}(k, t) .
 ```
 
-The variables involved are $u$ and its Fourier transform $\hat{u}$. Thus, we 
+The variables involved are ``u`` and its Fourier transform ``\hat{u}``. Thus, we 
 construct the `vars` struct as:
 
 ```@example 2
@@ -140,9 +139,9 @@ The `problem.clock` contains the time-step `dt` and the current `step` and time
 prob.clock
 ```
 
-Let's initiate our problem with, e.g., $u(x, 0) = \cos(\pi x)$, integrate up 
-to $t = 2$ and compare our numerical solution with the analytic solution 
-$u(x, t) = e^{-\alpha t} \cos(\pi x)$.
+Let's initiate our problem with, e.g., ``u(x, 0) = \cos(\pi x)``, integrate up 
+to ``t = 2`` and compare our numerical solution with the analytic solution 
+``u(x, t) = e^{-\alpha t} \cos(\pi x)``.
 
 ```@example 2
 u0 = @. cos(π * grid.x)
@@ -154,8 +153,8 @@ mul!(prob.sol, grid.rfftplan, u0)
 nothing # hide
 ```
 
-Since our time-step is chosen `dt=0.01`, we need to step forward `prob` for $200$ 
-time-steps to reach $t=2$.
+Since our time-step is chosen `dt=0.01`, we need to step forward `prob` for ``200`` 
+time-steps to reach ``t = 2``.
 
 ```@example 2
 stepforward!(prob, 200)
@@ -191,8 +190,8 @@ savefig("assets/plot4.svg"); nothing # hide
 
 ![](assets/plot4.svg)
 
-A good practice is to encompass all functions and type definitions related 
-with a PDE under a module, e.g.,
+A good practice is to encompass all functions and type definitions related with a PDE under 
+a single module, e.g.,
 
 ```julia
 module mypde
@@ -203,5 +202,5 @@ end # end module
 ```
 
 For a more elaborate example we urge you to have a look at the `Diffusion` 
-module found in `src/diffusion.jl` and also to the modules included in the 
+module located at `src/diffusion.jl` and also to the modules included in the 
 child package [GeophysicalFlows.jl](https://github.com/FourierFlows/GeophysicalFlows.jl).

--- a/docs/src/problem.md
+++ b/docs/src/problem.md
@@ -153,7 +153,7 @@ mul!(prob.sol, grid.rfftplan, u0)
 nothing # hide
 ```
 
-Since our time-step is chosen `dt=0.01`, we need to step forward `prob` for ``200`` 
+Since our time-step is chosen `dt = 0.01`, we need to step forward `prob` for ``200`` 
 time-steps to reach ``t = 2``.
 
 ```@example 2
@@ -176,10 +176,10 @@ and finally, let's plot our solution and compare with the analytic solution:
 using Plots
 
 plot(grid.x, prob.vars.u,
-        seriestype = :scatter,
-             label = "numerical",         
-            xlabel = "x",
-             title = "u(x, t=" * string(round(prob.clock.t, digits=2)) * ")")
+     seriestype = :scatter,
+          label = "numerical",         
+         xlabel = "x",
+          title = "u(x, t=" * string(round(prob.clock.t, digits=2)) * ")")
 
 plot!(x -> cos(π * x) * exp(-prob.params.α * 2), -1, 1, label = "analytical")
 

--- a/docs/src/problem.md
+++ b/docs/src/problem.md
@@ -142,7 +142,7 @@ prob.clock
 
 Let's initiate our problem with, e.g., $u(x, 0) = \cos(\pi x)$, integrate up 
 to $t = 2$ and compare our numerical solution with the analytic solution 
-$u(x, t) = \mathrm{e}^{-\alpha t} \cos(\pi x)$.
+$u(x, t) = e^{-\alpha t} \cos(\pi x)$.
 
 ```@example 2
 u0 = @. cos(π * grid.x)
@@ -180,7 +180,7 @@ plot(grid.x, prob.vars.u,
         seriestype = :scatter,
              label = "numerical",         
             xlabel = "x",
-             title = "u(x, t="*string(round(prob.clock.t, digits=2))*")")
+             title = "u(x, t=" * string(round(prob.clock.t, digits=2)) * ")")
 
 plot!(x -> cos(π * x) * exp(-prob.params.α * 2), -1, 1, label = "analytical")
 

--- a/examples/OneDShallowWaterGeostrophicAdjustment.jl
+++ b/examples/OneDShallowWaterGeostrophicAdjustment.jl
@@ -19,18 +19,17 @@
 # \end{aligned}
 # ```
 #
-# Above, ``g`` is the gravitational acceleration, ``f`` is the  Coriolis parameter,
-# and ``\mathrm{D}`` indicates a hyperviscous linear operator of the
-# form ``(-1)^{n_\nu} \nu \nabla^{2 n_\nu}``, with ``\nu`` the viscosity
-# coefficient and ``n_\nu`` the order of the operator.
+# Above, ``g`` is the gravitational acceleration, ``f`` is the  Coriolis parameter, and 
+# ``\mathrm{D}`` indicates a hyperviscous linear operator of the form ``(-1)^{n_ν} ν \nabla^{2 n_ν}``, 
+# with ``ν`` the viscosity coefficient and ``n_ν`` the order of the operator.
 #
 # Rotation introduces the deformation length scale, ``L_d = \sqrt{g H} / f``. 
 # Disturbances with length scales much smaller than ``L_d`` don't "feel" 
 # the rotation and propagate as inertia-gravity waves. Disturbances with 
 # length scales comparable or larger than ``L_d`` should be approximately 
 # in geostrophic balance, i.e., the Coriolis acceleration
-# ``f\widehat{\boldsymbol{z}} \times \boldsymbol{u}`` should be in approximate 
-# balance with the pressure gradient ``-g \boldsymbol{\nabla} \eta``.
+# ``f\widehat{z}} \times \bm{u}`` should be in approximate 
+# balance with the pressure gradient ``-g \bm{\nabla} \eta``.
 
 
 using FourierFlows, Plots
@@ -49,7 +48,7 @@ using Random
 # - `Grid` struct containining the physical and wavenumber grid for the problem,
 # - `Params` struct containining all the parameters of the problem,
 # - `Vars` struct containining arrays with the variables used in the problem,
-# - `Equation` struct containining the coefficients of the linear operator ``\mathcal{L}`` and the function that computes the nonlinear terms, usually named `calcN!()`.
+# - `Equation` struct containining the coefficients of the linear operator ``L`` and the function that computes the nonlinear terms, usually named `calcN!()`.
 # 
 # The `Grid` structure is provided by FourierFlows.jl. One simply has to call one of
 # the `OneDGrid()`, `TwoDGrid()`, or `ThreeDGrid()` grid constructors, depending
@@ -100,14 +99,14 @@ nothing #hide
 #
 # ```math
 # \begin{aligned}
-# \frac{\partial \hat{u}}{\partial t} & = \underbrace{ f \hat{v} - \mathrm{i} k g \hat{\eta} }_{\mathcal{N}_u} \; \underbrace{- \nu |\boldsymbol{k}|^2 }_{\mathcal{L}_u} \hat{u}, \\
-# \frac{\partial \hat{v}}{\partial t} & = \underbrace{ - f \hat{u} }_{\mathcal{N}_v} \; \underbrace{- \nu |\boldsymbol{k}|^2 }_{\mathcal{L}_v} \hat{v}, \\
-# \frac{\partial \hat{\eta}}{\partial t} & = \underbrace{ - \mathrm{i} k H \hat{u} }_{\mathcal{N}_{\eta}} \; \underbrace{- \nu |\boldsymbol{k}|^2 }_{\mathcal{L}_{\eta}} \hat{\eta}.
+# \frac{\partial \hat{u}}{\partial t} & = \underbrace{ f \hat{v} - i k g \hat{\eta} }_{N_u} \; \underbrace{- \nu |\bm{k}|^2 }_{L_u} \hat{u}, \\
+# \frac{\partial \hat{v}}{\partial t} & = \underbrace{ - f \hat{u} }_{N_v} \; \underbrace{- \nu |\bm{k}|^2 }_{L_v} \hat{v}, \\
+# \frac{\partial \hat{\eta}}{\partial t} & = \underbrace{ - i k H \hat{u} }_{N_{\eta}} \; \underbrace{- \nu |\bm{k}|^2 }_{L_{\eta}} \hat{\eta}.
 # \end{aligned}
 # ```
 # Although, e.g., terms involving the Coriolis accelaration are, in principle, 
-# linear we include them in the nonlinear term ``\mathcal{N}`` because they render 
-# the linear operator ``\mathcal{L}`` non-diagonal.
+# linear we include them in the nonlinear term ``N`` because they render 
+# the linear operator ``L`` non-diagonal.
 #
 # With these in mind, we construct function `calcN!` that computes the nonlinear terms.
 #
@@ -391,7 +390,7 @@ gif(anim, "onedshallowwater.gif", fps=18)
 
 # ## Geostrophic balance
 
-# It is instructive to compare the solution for ``v`` with its geostrophically balanced approximation, ``f \widehat{\boldsymbol{z}} \times \boldsymbol{u}_{\rm geostrophic} = - g \boldsymbol{\nabla} \eta``, i.e.,
+# It is instructive to compare the solution for ``v`` with its geostrophically balanced approximation, ``f \widehat{\bm{z}} \times \bm{u}_{\rm geostrophic} = - g \bm{\nabla} \eta``, i.e.,
 #
 # ```math
 # v_{\rm geostrophic} =   \frac{g}{f} \frac{\partial \eta}{\partial x} \ , \\
@@ -401,7 +400,7 @@ gif(anim, "onedshallowwater.gif", fps=18)
 # the center of the domain, after small-scale disturbances propagate away.
 
 u_geostrophic = zeros(grid.nx)  # -g/f ∂η/∂y = 0
-v_geostrophic = params.g/params.f * irfft(im * grid.kr .* vars.ηh, grid.nx)  #g/f ∂η/∂x
+v_geostrophic = params.g / params.f * irfft(im * grid.kr .* vars.ηh, grid.nx)  #g/f ∂η/∂x
 
 plot_u = plot(grid.x/1e3, [vars.u u_geostrophic],    # divide with 1e3 to convert m -> km
                  color = [:red :purple],


### PR DESCRIPTION
Simplifies, e.g., `\mathrm{e}^{\mathrm{i} k x}` -> `e^{i k x}`

Also adds a note regarding unicode symbols. Closes #229.