### PR TITLE
Adds parsevalsumr & parsevalsum2r for arrays that came from rfft

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -212,7 +212,7 @@ function radialspectrum(ah, grid::TwoDGrid; n=nothing, m=nothing, refinement=2)
   n = n == nothing ? refinement * maximum([grid.nk, grid.nl]) : n
   m = m == nothing ? refinement * maximum([grid.nk, grid.nl]) : m
 
-  # Calcualte shifted k and l
+  # Calculate shifted k and l
   lshift = range(-grid.nl/2+1, stop=grid.nl/2, length=grid.nl) * 2π/grid.Ly
 
   if size(ah)[1] == grid.nkr # conjugate symmetric form

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using
   FourierFlows,
   FourierFlows.Diffusion
 
-using FourierFlows: parsevalsum2
+using FourierFlows: parsevalsum2r
 
 using LinearAlgebra: mul!, ldiv!, norm
 
@@ -216,8 +216,8 @@ for dev in devices
     # Test on a rectangular grid
     nx, ny = 64, 128   # number of points
     Lx, Ly = 2π, 3π    # Domain width
-    g = TwoDGrid(dev, nx, Lx, ny, Ly)
-    x, y = gridpoints(g)
+    grid = TwoDGrid(dev, nx, Lx, ny, Ly)
+    x, y = gridpoints(grid)
     k0, l0 = 2π/Lx, 2π/Ly
 
     # Real and complex-valued functions
@@ -237,24 +237,24 @@ for dev in devices
     Jsinkl1sinkl2 = @. (k1*l2-k2*l1)*cos(k1*x + l1*y)*cos(k2*x + l2*y)
     Jexpkl1expkl2 = @. (k2*l1-k1*l2)*(cos((k1+k2)*x + (l1+l2)*y)+im*sin((k1+k2)*x + (l1+l2)*y))
 
-    @test test_parsevalsum(f1, g; realvalued=true)   # Real valued f with rfft
-    @test test_parsevalsum(f1, g; realvalued=false)  # Real valued f with fft
-    @test test_parsevalsum(f2, g; realvalued=false)  # Complex valued f with fft
-    @test test_parsevalsum2(f1, g; realvalued=true)  # Real valued f with rfft
-    @test test_parsevalsum2(f1, g; realvalued=false) # Real valued f with fft
-    @test test_parsevalsum2(f2, g; realvalued=false) # Complex valued f with fft
+    @test test_parsevalsum(f1, grid; realvalued=true)   # Real valued f with rfft
+    @test test_parsevalsum(f1, grid; realvalued=false)  # Real valued f with fft
+    @test test_parsevalsum(f2, grid; realvalued=false)  # Complex valued f with fft
+    @test test_parsevalsum2(f1, grid; realvalued=true)  # Real valued f with rfft
+    @test test_parsevalsum2(f1, grid; realvalued=false) # Real valued f with fft
+    @test test_parsevalsum2(f2, grid; realvalued=false) # Complex valued f with fft
 
-    @test test_jacobian(sinkl1, sinkl1, 0*sinkl1, g)      # Test J(a, a) = 0
-    @test test_jacobian(sinkl1, sinkl2, Jsinkl1sinkl2, g) # Test J(sin1, sin2) = Jsin1sin2
-    @test test_jacobian(expkl1, expkl2, Jexpkl1expkl2, g) # Test J(exp1, exp2) = Jexp1exps2
+    @test test_jacobian(sinkl1, sinkl1, 0*sinkl1, grid)      # Test J(a, a) = 0
+    @test test_jacobian(sinkl1, sinkl2, Jsinkl1sinkl2, grid) # Test J(sin1, sin2) = Jsin1sin2
+    @test test_jacobian(expkl1, expkl2, Jexpkl1expkl2, grid) # Test J(exp1, exp2) = Jexp1exps2
 
     @test test_zeros()
     
-    g = OneDGrid(dev, nx, Lx)
+    grid = OneDGrid(dev, nx, Lx)
     σ = 0.5
-    f1 = @. exp(-g.x^2/(2σ^2))
-    @test test_parsevalsum2(f1, g; realvalued=true)  # Real valued f with rfft
-    @test test_parsevalsum2(f1, g; realvalued=false) # Real valued f with fft
+    f1 = @. exp(-grid.x^2/(2σ^2))
+    @test test_parsevalsum2(f1, grid; realvalued=true)  # Real valued f with rfft
+    @test test_parsevalsum2(f1, grid; realvalued=false) # Real valued f with fft
 
     
     # Radial spectrum tests. Note that ahρ = ∫ ah ρ dθ.

--- a/test/test_diagnostics.jl
+++ b/test/test_diagnostics.jl
@@ -22,7 +22,7 @@ function test_scalardiagnostics(dev::Device=CPU(); nx=6, Lx=2π, κ=1e-2, nsteps
 
   set_c!(prob, c0)
 
-  variance(prob) = parsevalsum2(prob.sol, prob.grid) / Lx
+  variance(prob) = parsevalsum2r(prob.sol, prob.grid) / Lx
   diagnostic = Diagnostic(variance, prob, nsteps=nsteps, freq=freq, ndata=ndata)
 
   stepforward!(prob, diagnostic, nsteps)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -83,10 +83,14 @@ function test_parsevalsum(func, grid; realvalued=true)
   # Compute integral in physical space
   integral = integralsquare(func, grid)
   # Compute integral in wavenumber space using Parseval's theorem
-  if realvalued==true;      funch = rfft(func)
-  elseif realvalued==false; funch = fft(func)
+  if realvalued==true
+    funch = rfft(func)
+    parsevalsum = FourierFlows.parsevalsumr(abs2.(funch), grid)
+  elseif realvalued==false
+    funch = fft(func)
+    parsevalsum = FourierFlows.parsevalsum(abs2.(funch), grid)
   end
-  parsevalsum = FourierFlows.parsevalsum(abs2.(funch), grid)
+  
   isapprox(integral, parsevalsum; rtol=rtol_utils)
 end
 
@@ -94,10 +98,14 @@ function test_parsevalsum2(func, grid; realvalued=true)
   # Compute integral in physical space
   integral = integralsquare(func, grid)
   # Compute integral in wavenumber space using Parseval's theorem
-  if realvalued==true;      funch = rfft(func)
-  elseif realvalued==false; funch = fft(func)
+  if realvalued==true
+    funch = rfft(func)
+    parsevalsum2 = FourierFlows.parsevalsum2r(funch, grid)
+  elseif realvalued==false
+    funch = fft(func)
+    parsevalsum2 = FourierFlows.parsevalsum2(funch, grid)
   end
-  parsevalsum2 = FourierFlows.parsevalsum2(funch, grid)
+  
   isapprox(integral, parsevalsum2; rtol=rtol_utils)
 end
 


### PR DESCRIPTION
This PR adds two functions in `utils.jl`, `parsevalsumr` and `parsevalsum2r` which require as input complex-valued arrays that came from real-valued FFTs (`rfft`). This way we avoid `if` statements within `parsevalsum()` and `parsevalsum2()`.

Closes #239.

This will bring breaking changes and a minor release is in order.