### PR TITLE
Generalizes tests to work on Julia v1.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.5
+  - julia_version: 1.6
   - julia_version: nightly
 
 platform:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,7 +39,7 @@ include("createffttestfunctions.jl")
 
 for dev in devices
   
-  println("testing on " * string(typeof(dev)))
+  @info "testing on " * string(typeof(dev))
   
   @time @testset "Grid tests" begin
     include("test_grid.jl")
@@ -344,8 +344,13 @@ for dev in devices
       @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element " * string(ArrayType(dev)) * "{Float64,1}\n  ├───── variable: cx -> 128-element " * string(ArrayType(dev)) * "{Float64,1}\n  ├───── variable: ch -> 65-element " * string(ArrayType(dev)) * "{Complex{Float64},1}\n  └───── variable: cxh -> 65-element " * string(ArrayType(dev)) * "{Complex{Float64},1}\n"
       @test repr(prob.eqn) == "Equation\n  ├──────── linear coefficients: L\n  │                              ├───type: Int64\n  │                              └───size: (65,)\n  ├───────────── nonlinear term: calcN!()\n  └─── type of state vector sol: Complex{Float64}"
     else
-      @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element Vector{Float64}\n  ├───── variable: cx -> 128-element Vector{Float64}\n  ├───── variable: ch -> 65-element Vector{ComplexF64}\n  └───── variable: cxh -> 65-element Vector{ComplexF64}\n"
-      @test repr(prob.eqn) == "Equation\n  ├──────── linear coefficients: L\n  │                              ├───type: Int64\n  │                              └───size: (65,)\n  ├───────────── nonlinear term: calcN!()\n  └─── type of state vector sol: ComplexF64"
+      if dev == CPU()
+        @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element Vector{Float64}\n  ├───── variable: cx -> 128-element Vector{Float64}\n  ├───── variable: ch -> 65-element Vector{ComplexF64}\n  └───── variable: cxh -> 65-element Vector{ComplexF64}\n"
+        @test repr(prob.eqn) == "Equation\n  ├──────── linear coefficients: L\n  │                              ├───type: Int64\n  │                              └───size: (65,)\n  ├───────────── nonlinear term: calcN!()\n  └─── type of state vector sol: ComplexF64"
+      else
+        @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element Vector{Float64}\n  ├───── variable: cx -> 128-element " * string(ArrayType(dev)) * "{Float64}\n  ├───── variable: ch -> 65-element " * string(ArrayType(dev)) * "{ComplexF64}\n  └───── variable: cxh -> 65-element " * string(ArrayType(dev)) * "{ComplexF64}\n"
+        @test repr(prob.eqn) == "Equation\n  ├──────── linear coefficients: L\n  │                              ├───type: Int64\n  │                              └───size: (65,)\n  ├───────────── nonlinear term: calcN!()\n  └─── type of state vector sol: ComplexF64"
+      end
     end
     @test repr(prob.clock) == "Clock\n  ├─── timestep dt: 0.01\n  ├────────── step: 0\n  └──────── time t: 0.0"
     @test repr(prob) == "Problem\n  ├─────────── grid: grid (on " * FourierFlows.griddevice(prob.grid) * ")\n  ├───── parameters: params\n  ├────── variables: vars\n  ├─── state vector: sol\n  ├─────── equation: eqn\n  ├────────── clock: clock\n  └──── timestepper: RK4TimeStepper"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -346,11 +346,10 @@ for dev in devices
     else
       if dev == CPU()
         @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element Vector{Float64}\n  ├───── variable: cx -> 128-element Vector{Float64}\n  ├───── variable: ch -> 65-element Vector{ComplexF64}\n  └───── variable: cxh -> 65-element Vector{ComplexF64}\n"
-        @test repr(prob.eqn) == "Equation\n  ├──────── linear coefficients: L\n  │                              ├───type: Int64\n  │                              └───size: (65,)\n  ├───────────── nonlinear term: calcN!()\n  └─── type of state vector sol: ComplexF64"
       else
-        @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element Vector{Float64}\n  ├───── variable: cx -> 128-element " * string(ArrayType(dev)) * "{Float64}\n  ├───── variable: ch -> 65-element " * string(ArrayType(dev)) * "{ComplexF64}\n  └───── variable: cxh -> 65-element " * string(ArrayType(dev)) * "{ComplexF64}\n"
-        @test repr(prob.eqn) == "Equation\n  ├──────── linear coefficients: L\n  │                              ├───type: Int64\n  │                              └───size: (65,)\n  ├───────────── nonlinear term: calcN!()\n  └─── type of state vector sol: ComplexF64"
+        @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element " * string(ArrayType(dev)) * "{Float64}\n  ├───── variable: cx -> 128-element " * string(ArrayType(dev)) * "{Float64}\n  ├───── variable: ch -> 65-element " * string(ArrayType(dev)) * "{ComplexF64}\n  └───── variable: cxh -> 65-element " * string(ArrayType(dev)) * "{ComplexF64}\n"
       end
+      @test repr(prob.eqn) == "Equation\n  ├──────── linear coefficients: L\n  │                              ├───type: Int64\n  │                              └───size: (65,)\n  ├───────────── nonlinear term: calcN!()\n  └─── type of state vector sol: ComplexF64"
     end
     @test repr(prob.clock) == "Clock\n  ├─── timestep dt: 0.01\n  ├────────── step: 0\n  └──────── time t: 0.0"
     @test repr(prob) == "Problem\n  ├─────────── grid: grid (on " * FourierFlows.griddevice(prob.grid) * ")\n  ├───── parameters: params\n  ├────── variables: vars\n  ├─── state vector: sol\n  ├─────── equation: eqn\n  ├────────── clock: clock\n  └──── timestepper: RK4TimeStepper"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -258,16 +258,16 @@ for dev in devices
 
     
     # Radial spectrum tests. Note that ahρ = ∫ ah ρ dθ.
-    n = 128; δ = n/10                 # Parameters
-    ahkl(k, l) = exp(-(k^2+l^2)/2δ^2) # a  = exp(-ρ²/2δ²)
-        ahρ(ρ) = 2π*ρ*exp(-ρ^2/2δ^2)  # aᵣ = 2π ρ exp(-ρ²/2δ²)
-    @test test_radialspectrum(dev, n, ahkl, ahρ)
-    @test test_radialspectrum(dev, n, ahkl, ahρ; rfft=true)
+    n = 128; δ = n/10                                       # Parameters
+    ahkl_isotropic(k, l) = exp(-(k^2 + l^2) / 2δ^2)                     # a  = exp(-ρ²/2δ²)
+    ahρ_isotropic(ρ) = 2π * ρ * exp(-ρ^2 / 2δ^2)                        # aᵣ = 2π ρ exp(-ρ²/2δ²)
+    @test test_radialspectrum(dev, n, ahkl_isotropic, ahρ_isotropic)
+    @test test_radialspectrum(dev, n, ahkl_isotropic, ahρ_isotropic; rfft=true)
 
-    ahkl(k, l) = exp(-(k^2+l^2)/2δ^2) * k^2/(k^2+l^2) # a  = exp(-ρ²/2δ²)*cos(θ)²
-        ahρ(ρ) = π*ρ*exp(-ρ^2/2δ^2)                   # aᵣ = π ρ exp(-ρ²/2δ²)
-    @test test_radialspectrum(dev, n, ahkl, ahρ)
-    @test test_radialspectrum(dev, n, ahkl, ahρ; rfft=true)
+    ahkl_anisotropic(k, l) = exp(-(k^2 + l^2) / 2δ^2) * k^2 / (k^2+l^2) # a  = exp(-ρ²/2δ²) cos²θ
+    ahρ_anisotropic(ρ) = π * ρ * exp(-ρ^2/2δ^2)                         # aᵣ = π ρ exp(-ρ²/2δ²)
+    @test test_radialspectrum(dev, n, ahkl_anisotropic, ahρ_anisotropic)
+    @test test_radialspectrum(dev, n, ahkl_anisotropic, ahρ_anisotropic; rfft=true)
     @test test_ongrid(dev)
   end
 
@@ -340,10 +340,15 @@ for dev in devices
     
     @test repr(prob1.params) == "Parameters\n  ├───── parameter: κ1 -> Float64\n  ├───── parameter: κ2 -> Float64\n  └───── parameter: func -> Function\n"
     @test repr(prob2.params) == "Parameters\n  ├───── parameter: κ1 -> Float64\n  ├───── parameter: func -> Function\n  └───── parameter: κ2 -> Float64\n"
-    @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element "*string(ArrayType(dev))*"{Float64,1}\n  ├───── variable: cx -> 128-element "*string(ArrayType(dev))*"{Float64,1}\n  ├───── variable: ch -> 65-element "*string(ArrayType(dev))*"{Complex{Float64},1}\n  └───── variable: cxh -> 65-element "*string(ArrayType(dev))*"{Complex{Float64},1}\n"
-    @test repr(prob.eqn) == "Equation\n  ├──────── linear coefficients: L\n  │                              ├───type: Int64\n  │                              └───size: (65,)\n  ├───────────── nonlinear term: calcN!()\n  └─── type of state vector sol: Complex{Float64}"
+    if VERSION < v"1.6"
+      @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element " * string(ArrayType(dev)) * "{Float64,1}\n  ├───── variable: cx -> 128-element " * string(ArrayType(dev)) * "{Float64,1}\n  ├───── variable: ch -> 65-element " * string(ArrayType(dev)) * "{Complex{Float64},1}\n  └───── variable: cxh -> 65-element " * string(ArrayType(dev)) * "{Complex{Float64},1}\n"
+      @test repr(prob.eqn) == "Equation\n  ├──────── linear coefficients: L\n  │                              ├───type: Int64\n  │                              └───size: (65,)\n  ├───────────── nonlinear term: calcN!()\n  └─── type of state vector sol: Complex{Float64}"
+    else
+      @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element Vector{Float64}\n  ├───── variable: cx -> 128-element Vector{Float64}\n  ├───── variable: ch -> 65-element Vector{ComplexF64}\n  └───── variable: cxh -> 65-element Vector{ComplexF64}\n"
+      @test repr(prob.eqn) == "Equation\n  ├──────── linear coefficients: L\n  │                              ├───type: Int64\n  │                              └───size: (65,)\n  ├───────────── nonlinear term: calcN!()\n  └─── type of state vector sol: ComplexF64"
+    end
     @test repr(prob.clock) == "Clock\n  ├─── timestep dt: 0.01\n  ├────────── step: 0\n  └──────── time t: 0.0"
-    @test repr(prob) == "Problem\n  ├─────────── grid: grid (on "*FourierFlows.griddevice(prob.grid)*")\n  ├───── parameters: params\n  ├────── variables: vars\n  ├─── state vector: sol\n  ├─────── equation: eqn\n  ├────────── clock: clock\n  └──── timestepper: RK4TimeStepper"
+    @test repr(prob) == "Problem\n  ├─────────── grid: grid (on " * FourierFlows.griddevice(prob.grid) * ")\n  ├───── parameters: params\n  ├────── variables: vars\n  ├─── state vector: sol\n  ├─────── equation: eqn\n  ├────────── clock: clock\n  └──── timestepper: RK4TimeStepper"
   end
 
 end # end loop over devices

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,7 +347,7 @@ for dev in devices
       if dev == CPU()
         @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element Vector{Float64}\n  ├───── variable: cx -> 128-element Vector{Float64}\n  ├───── variable: ch -> 65-element Vector{ComplexF64}\n  └───── variable: cxh -> 65-element Vector{ComplexF64}\n"
       else
-        @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element " * string(ArrayType(dev)) * "{Float64}\n  ├───── variable: cx -> 128-element " * string(ArrayType(dev)) * "{Float64}\n  ├───── variable: ch -> 65-element " * string(ArrayType(dev)) * "{ComplexF64}\n  └───── variable: cxh -> 65-element " * string(ArrayType(dev)) * "{ComplexF64}\n"
+        @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element " * string(ArrayType(dev)) * "{Float64, 1}\n  ├───── variable: cx -> 128-element " * string(ArrayType(dev)) * "{Float64, 1}\n  ├───── variable: ch -> 65-element " * string(ArrayType(dev)) * "{ComplexF64, 1}\n  └───── variable: cxh -> 65-element " * string(ArrayType(dev)) * "{ComplexF64, 1}\n"
       end
       @test repr(prob.eqn) == "Equation\n  ├──────── linear coefficients: L\n  │                              ├───type: Int64\n  │                              └───size: (65,)\n  ├───────────── nonlinear term: calcN!()\n  └─── type of state vector sol: ComplexF64"
     end


### PR DESCRIPTION
Tests on Julia v1.6 were failing. The root of the manner was the methods for `show()` that use `summary()` function. Julia v1.6 introduced a new subtype for Arrays:
```Julia
julia> typeof(zeros(2,))
Vector{Float64} (alias for Array{Float64, 1})

julia> typeof(zeros(2, 1))
Matrix{Float64} (alias for Array{Float64, 2})
```
and so `summary()` spits out `Vector` or `Matrix` accordingly. Also, `Complex{Float64}` was renamed to `ComplexF64`.

This fix involves some `if` statements. 

@glwagner if you have a more elegant way of dealing with it let me know!

Closes #263.