### PR TITLE
Reexport basic functionality from other packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ authors = ["Gregory L. Wagner <wagner.greg@gmail.com>", "Navid C. Constantinou <
 description = "Tools for building fast, hackable, pseudospectral partial differential equation solvers on periodic domains."
 documentation = "https://fourierflows.github.io/FourierFlowsDocumentation/stable/"
 repository = "https://github.com/FourierFlows/FourierFlows.jl"
-version = "0.6.16"
+version = "0.6.17"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ and [Navid C. Constantinou][] (@navidcy).
 
 The code is citable via [zenodo](https://zenodo.org). Please cite as:
 
-> Navid C. Constantinou & Gregory L. Wagner. (2021). FourierFlows/FourierFlows.jl: FourierFlows v0.6.16 (Version v0.6.16). Zenodo.  [http://doi.org/10.5281/zenodo.1161724](http://doi.org/10.5281/zenodo.1161724)
+> Navid C. Constantinou & Gregory L. Wagner. (2021). FourierFlows/FourierFlows.jl: FourierFlows v0.6.17 (Version v0.6.17). Zenodo.  [http://doi.org/10.5281/zenodo.1161724](http://doi.org/10.5281/zenodo.1161724)
 
 
 [Julia]: https://julialang.org/

--- a/examples/OneDShallowWaterGeostrophicAdjustment.jl
+++ b/examples/OneDShallowWaterGeostrophicAdjustment.jl
@@ -32,11 +32,8 @@
 # balance with the pressure gradient ``-g \bm{\nabla} \eta``.
 
 
-using FourierFlows, Plots
-using FFTW: rfft, irfft
+using FourierFlows, Plots, Printf, Random
 using LinearAlgebra: mul!, ldiv!
-using Printf
-using Random
 
 # ## Coding up the equations
 # ### A demonstration of FourierFlows.jl framework

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -69,7 +69,10 @@ using
   Statistics,
   Interpolations,
   CUDA,
+  Reexport,
   DocStringExtensions
+
+@reexport using FFTW: fft, ifft, rfft, irfft
 
 import Base: resize!, getindex, setindex!, push!, append!, show, summary
 

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -68,12 +68,11 @@ using
   JLD2,
   Statistics,
   Interpolations,
-  CUDA,
   Reexport,
   DocStringExtensions
 
 @reexport using FFTW: fft, ifft, rfft, irfft
-@reexport using CUDA: @allowscalar, @disallowscalar, allowscalar
+@reexport using CUDA
 
 import Base: resize!, getindex, setindex!, push!, append!, show, summary
 

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -73,6 +73,7 @@ using
   DocStringExtensions
 
 @reexport using FFTW: fft, ifft, rfft, irfft
+@reexport using CUDA: @allowscalar, @disallowscalar, allowscalar
 
 import Base: resize!, getindex, setindex!, push!, append!, show, summary
 


### PR DESCRIPTION
This PR makes sure that FourierFlows.jl re-exports some functions from other packages that it depends on. Specifically:

- `FFTW: fft, ifft, rfft, irfft`
- `CUDA: CUDA: @allowscalar, @disallowscalar, allowscalar`

(This was inspired by @pdebuyl's remark in [JOSS paper review](https://github.com/openjournals/joss-reviews/issues/3053#issuecomment-818964253).)