### PR TITLE
Drop the in-house `@has_cuda` macro

### DIFF
--- a/test/createffttestfunctions.jl
+++ b/test/createffttestfunctions.jl
@@ -139,7 +139,7 @@ function create_testfuncs(g::ThreeDGrid{Tg,<:Array}) where Tg
 end
 
 
-@has_cuda begin
+if CUDA.has_cuda()
   function create_testfuncs(g::OneDGrid{Tg, <:CuArray}) where Tg
     cpugrid = OneDGrid(g.nx, g.Lx)
     out = create_testfuncs(cpugrid)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,8 @@ using
 using
   FourierFlows,
   FourierFlows.Diffusion
+  
+using FourierFlows: parsevalsum2
 
 using LinearAlgebra: mul!, ldiv!, norm
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using
 using LinearAlgebra: mul!, ldiv!, norm
 
 # the devices on which tests will run
-devices = CUDA.has_cuda() ? (CPU(),) : (CPU(), GPU())
+devices = CUDA.has_cuda() ? (CPU(), GPU()) : (CPU(),)
 
 const rtol_fft = 1e-12
 const rtol_output = 1e-12

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,20 +3,16 @@ using
   LinearAlgebra,
   Printf,
   JLD2,
-  CUDA,
   Test
 
 using
   FourierFlows,
   FourierFlows.Diffusion
 
-using FourierFlows: parsevalsum2
-
 using LinearAlgebra: mul!, ldiv!, norm
 
 # the devices on which tests will run
-devices = (CPU(),)
-@has_cuda devices = (CPU(), GPU())
+devices = CUDA.has_cuda() ? (CPU(),) : (CPU(), GPU())
 
 const rtol_fft = 1e-12
 const rtol_output = 1e-12

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using
 using
   FourierFlows,
   FourierFlows.Diffusion
-  
+
 using FourierFlows: parsevalsum2
 
 using LinearAlgebra: mul!, ldiv!, norm


### PR DESCRIPTION
This PR drops the `FourierFlows.@has_cuda` macro in favor of `CUDA.has_cuda()`.