### PR TITLE
Use latest format `typeof(CuArray)` in test `show(::AbstractVars)`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -361,7 +361,7 @@ for dev in devices
       if dev == CPU()
         @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element Vector{Float64}\n  ├───── variable: cx -> 128-element Vector{Float64}\n  ├───── variable: ch -> 65-element Vector{ComplexF64}\n  └───── variable: cxh -> 65-element Vector{ComplexF64}\n"
       else
-        @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element " * string(ArrayType(dev)) * "{Float64, 1}\n  ├───── variable: cx -> 128-element " * string(ArrayType(dev)) * "{Float64, 1}\n  ├───── variable: ch -> 65-element " * string(ArrayType(dev)) * "{ComplexF64, 1}\n  └───── variable: cxh -> 65-element " * string(ArrayType(dev)) * "{ComplexF64, 1}\n"
+        @test repr(prob.vars) == "Variables\n  ├───── variable: c -> 128-element " * string(ArrayType(dev)) * "{Float64, 1, CUDA.Mem.DeviceBuffer}\n  ├───── variable: cx -> 128-element " * string(ArrayType(dev)) * "{Float64, 1, CUDA.Mem.DeviceBuffer}\n  ├───── variable: ch -> 65-element " * string(ArrayType(dev)) * "{ComplexF64, 1, CUDA.Mem.DeviceBuffer}\n  └───── variable: cxh -> 65-element " * string(ArrayType(dev)) * "{ComplexF64, 1, CUDA.Mem.DeviceBuffer}\n"
       end
       @test repr(prob.eqn) == "Equation\n  ├──────── linear coefficients: L\n  │                              ├───type: Int64\n  │                              └───size: (65,)\n  ├───────────── nonlinear term: calcN!()\n  └─── type of state vector sol: ComplexF64"
     end


### PR DESCRIPTION
Adjusted tests for `show()` after some changes in `CuArrays` types.

Previously
```Julia
julia> typeof(CuArray(rand(3, 4)))
CuArray{Float64, 2}
```
while now
```Julia
julia> typeof(CuArray(rand(3, 4)))
CuArray{Float64, 2, CUDA.Mem.DeviceBuffer}
```