### PR TITLE
Adds kwarg `devbranch="main"` in `docs.make.jl`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -79,6 +79,7 @@ makedocs(
 withenv("GITHUB_REPOSITORY" => "FourierFlows/FourierFlowsDocumentation") do
   deploydocs(        repo = "github.com/FourierFlows/FourierFlowsDocumentation.git",
                  versions = ["stable" => "v^", "v#.#", "dev" => "dev"],
-             push_preview = false
+             push_preview = false,
+                devbranch = "main"
   )
 end


### PR DESCRIPTION
This is required after renaming developer branch from `master`->`main`.