### PR TITLE
Remove extra substep in ETDRK4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ authors = ["Gregory L. Wagner <wagner.greg@gmail.com>", "Navid C. Constantinou <
 description = "Tools for building fast, hackable, pseudospectral partial differential equation solvers on periodic domains."
 documentation = "https://fourierflows.github.io/FourierFlowsDocumentation/stable/"
 repository = "https://github.com/FourierFlows/FourierFlows.jl"
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/timesteppers.jl
+++ b/src/timesteppers.jl
@@ -371,7 +371,6 @@ function ETDRK4substeps!(sol, clock, ts, eq, vars, params, grid)
   # Substep 1
   eq.calcN!(ts.N₁, sol, clock.t, clock, vars, params, grid)
   ETDRK4substep12!(ts.sol₁, ts.exp½Ldt, sol, ts.ζ, ts.N₁)
-  @. ts.sol₁ = ts.exp½Ldt * sol + ts.ζ * ts.N₁
 
   # Substep 2
   t2 = clock.t + clock.dt/2


### PR DESCRIPTION
It seems that only one of `ETDRK4substep12!(ts.sol₁, ts.exp½Ldt, sol, ts.ζ, ts.N₁)` or `@. ts.sol₁ = ts.exp½Ldt * sol + ts.ζ * ts.N₁` is needed as the first substep in ETDRK4. They both operate on the same array in place using the same arguments, so perform identical operations. As a further check, removing either passes the tests.