### PR TITLE
Add `gridpoints(::OneDGrid)` and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ coverage/
 # MacOS stuff
 *.DS_Store
 
+# vs code
+*.vscode

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -359,11 +359,18 @@ TwoDGrid(dev::CPU, args...; kwargs...) = TwoDGrid(args...; ArrayType=Array, kwar
 ThreeDGrid(dev::CPU, args...; kwargs...) = ThreeDGrid(args...; ArrayType=Array, kwargs...)
 
 """
+    gridpoints(grid::OneDDGrid)
     gridpoints(grid::TwoDGrid)
     gridpoints(grid::ThreeDGrid)
 
-Returns the collocation points of the `grid` in 2D or 3D arrays `X, Y` (and `Z`).
+Returns the collocation points of the `grid` in 1D (`X`),  2D (`X, Y`) or 3D arrays (`X, Y, Z`).
 """
+function gridpoints(grid::OneDGrid{T, A}) where {T, A}
+  X = [ grid.x[i] for i=1:grid.nx ]
+
+  return A(X)
+end
+
 function gridpoints(grid::TwoDGrid{T, A}) where {T, A}
   X = [ grid.x[i₁] for i₁=1:grid.nx, i₂=1:grid.ny ]
   Y = [ grid.y[i₂] for i₁=1:grid.nx, i₂=1:grid.ny ] 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,6 +56,7 @@ for dev in devices
     @test testx(g₁)
     @test testk(g₁)
     @test testkr(g₁)
+    @test testgridpoints(dev, g₁)
     @test testdealias(g₁)
     @test testmakefilter(dev, g₁)
 

--- a/test/test_grid.jl
+++ b/test/test_grid.jl
@@ -47,6 +47,14 @@ testl(g::Union{TwoDGrid, ThreeDGrid}) = testwavenumberalignment(g.l, g.ny)
 testm(g::ThreeDGrid) = testwavenumberalignment(g.m, g.nz)
 testkr(g) = CUDA.@allowscalar isapprox(cat(g.k[1:g.nkr-1], abs(g.k[g.nkr]), dims=1), g.kr)
 
+function testgridpoints(dev::Device, g::OneDGrid{T}) where T
+  X = gridpoints(g)
+  dXgrid = @. X[2:end, :] - X[1:end-1, :]
+  dXones = ArrayType(dev)(g.dx*ones(T, size(dXgrid)))
+
+return isapprox(dXgrid, dXones)
+end
+
 function testgridpoints(dev::Device, g::TwoDGrid{T}) where T
   X, Y = gridpoints(g)
   dXgrid = @. X[2:end, :] - X[1:end-1, :]


### PR DESCRIPTION
This PR adds the `gridpoints(::Dev, ::OneDGrid)` method so that one can call `x = gridpoints(x)`. This will make sure that the  type of array is correct for the `dev` either `CPU` or `GPU`.