### PR TITLE
Only save computed diagnostic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ authors = ["Gregory L. Wagner <wagner.greg@gmail.com>", "Navid C. Constantinou <
 description = "Tools for building fast, hackable, pseudospectral partial differential equation solvers on periodic domains."
 documentation = "https://fourierflows.github.io/FourierFlowsDocumentation/stable/"
 repository = "https://github.com/FourierFlows/FourierFlows.jl"
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ and [Navid C. Constantinou][] (@navidcy).
 
 The code is citable via [zenodo](https://zenodo.org). Please cite as:
 
-> Gregory L. Wagner, Navid C. Constantinou, and contributors. (2022). FourierFlows/FourierFlows.jl: FourierFlows v0.9.1 (Version v0.9.1). Zenodo.  [http://doi.org/10.5281/zenodo.1161724](http://doi.org/10.5281/zenodo.1161724)
+> Gregory L. Wagner, Navid C. Constantinou, and contributors. (2022). FourierFlows/FourierFlows.jl: FourierFlows v0.9.3 (Version v0.9.3). Zenodo. [http://doi.org/10.5281/zenodo.1161724](http://doi.org/10.5281/zenodo.1161724)
 
 
 ## Contributing

--- a/src/output.jl
+++ b/src/output.jl
@@ -145,16 +145,16 @@ end
 saveproblem(out::Output) = saveproblem(out.prob, out.path)
 
 """
-    savediagnostic(diag, diagname, filename)
+    savediagnostic(diagnostic, diagname, filename)
 
-Save diagnostic in `diag` to `filename` under name `diagname`. Only the computed diagnostic
-is saved, that is, everything up to diagnostic's iteration `diag.i`.
+Save `diagnostic` to `filename` under name `diagname`. Only the computed diagnostic
+is saved, that is, everything up to diagnostic's iteration `diagnostics.i`.
 """
-function savediagnostic(diag, diagname, filename)
+function savediagnostic(diagnostic, diagname, filename)
   jldopen(filename, "a+") do file
-    file["diags/$diagname/steps"] = diag.steps[1:diag.i]
-    file["diags/$diagname/t"] = diag.t[1:diag.i]
-    file["diags/$diagname/data"] = diag.data[1:diag.i]
+    file["diagnostics/$diagname/steps"] = diagnostic.steps[1:diagnostic.i]
+    file["diagnostics/$diagname/t"] = diagnostic.t[1:diagnostic.i]
+    file["diagnostics/$diagname/data"] = diagnostic.data[1:diagnostic.i]
   end
   
   return nothing

--- a/src/output.jl
+++ b/src/output.jl
@@ -148,7 +148,7 @@ saveproblem(out::Output) = saveproblem(out.prob, out.path)
     savediagnostic(diagnostic, diagname, filename)
 
 Save `diagnostic` to `filename` under name `diagname`. Only the computed diagnostic
-is saved, that is, everything up to diagnostic's iteration `diagnostics.i`.
+is saved, that is, everything up to diagnostic's iteration `diagnostic.i`.
 """
 function savediagnostic(diagnostic, diagname, filename)
   jldopen(filename, "a+") do file

--- a/src/output.jl
+++ b/src/output.jl
@@ -147,13 +147,14 @@ saveproblem(out::Output) = saveproblem(out.prob, out.path)
 """
     savediagnostic(diag, diagname, filename)
 
-Save diagnostics in `diag` to `filename`, labeled by `diagname`.
+Save diagnostic in `diag` to `filename` under name `diagname`. Only the computed diagnostic
+is saved, that is, everything up to diagnostic's iteration `diag.i`.
 """
 function savediagnostic(diag, diagname, filename)
   jldopen(filename, "a+") do file
-    file["diags/$diagname/steps"] = diag.steps
-    file["diags/$diagname/t"] = diag.t
-    file["diags/$diagname/data"] = diag.data
+    file["diags/$diagname/steps"] = diag.steps[1:diag.i]
+    file["diags/$diagname/t"] = diag.t[1:diag.i]
+    file["diags/$diagname/data"] = diag.data[1:diag.i]
   end
   
   return nothing

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -112,11 +112,11 @@ function test_savediagnostic(dev::Device=CPU())
   prob = Problem(dev; nx=6, Lx=2π)
   getone(prob) = 1
   nsteps = 100
-  freq = 1
+  freq = 2
   ndata = ceil(Int, (nsteps+1)/freq)
   d = Diagnostic(getone, prob; nsteps, freq, ndata)
   
-  nsteps = 105 #just to check what happens if we time-step a bit longer than the size of the diagnostic
+  nsteps += 5 #to check what happens if we time-step a bit longer than the size of the diagnostic
   stepforward!(prob, d, nsteps)
   expectedsteps = cat([0], freq:freq:nsteps, dims=1)
   

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -128,8 +128,8 @@ function test_savediagnostic(dev::Device=CPU())
   file = jldopen(filename)
   
   return isfile(filename) &&
-         file["diags"]["mydiagnostic"]["steps"] == expectedsteps &&
-         file["diags"]["mydiagnostic"]["data"] == d.data[1:d.i]
+         file["diagnostics"]["mydiagnostic"]["steps"] == expectedsteps &&
+         file["diagnostics"]["mydiagnostic"]["data"] == d.data[1:d.i]
 end
 
 struct TestbedParams{T, Trfft} <: AbstractParams

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -108,13 +108,15 @@ end
 function test_savediagnostic(dev::Device=CPU())
   filename = joinpath(".", "testoutput.jld2")
   if isfile(filename); GC.gc(); rm(filename); end
-
+  
   prob = Problem(dev; nx=6, Lx=2π)
   getone(prob) = 1
   nsteps = 100
   freq = 1
   ndata = ceil(Int, (nsteps+1)/freq)
   d = Diagnostic(getone, prob; nsteps, freq, ndata)
+  
+  nsteps = 105 #just to check what happens if we time-step a bit longer than the size of the diagnostic
   stepforward!(prob, d, nsteps)
   expectedsteps = cat([0], freq:freq:nsteps, dims=1)
   
@@ -125,7 +127,9 @@ function test_savediagnostic(dev::Device=CPU())
   
   file = jldopen(filename)
   
-  return isfile(filename) && file["diags"]["mydiagnostic"]["steps"] == expectedsteps
+  return isfile(filename) &&
+         file["diags"]["mydiagnostic"]["steps"] == expectedsteps &&
+         file["diags"]["mydiagnostic"]["data"] == d.data[1:d.i]
 end
 
 struct TestbedParams{T, Trfft} <: AbstractParams


### PR DESCRIPTION
This PR modifies `savediagnostic` slightly so it only saves the diagnostic that were computed, i.e., `1 : diag.i`.