### PR TITLE
Always load the GPU functionality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ authors = ["Gregory L. Wagner <wagner.greg@gmail.com>", "Navid C. Constantinou <
 description = "Tools for building fast, hackable, pseudospectral partial differential equation solvers on periodic domains."
 documentation = "https://fourierflows.github.io/FourierFlowsDocumentation/stable/"
 repository = "https://github.com/FourierFlows/FourierFlows.jl"
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ and [Navid C. Constantinou][] (@navidcy).
 
 The code is citable via [zenodo](https://zenodo.org). Please cite as:
 
-> Gregory L. Wagner, Navid C. Constantinou, and contributors. (2022). FourierFlows/FourierFlows.jl: FourierFlows v0.9.3 (Version v0.9.3). Zenodo. [http://doi.org/10.5281/zenodo.1161724](http://doi.org/10.5281/zenodo.1161724)
+> Gregory L. Wagner, Navid C. Constantinou, and contributors. (2022). FourierFlows/FourierFlows.jl: FourierFlows v0.9.4 (Version v0.9.4). Zenodo. [http://doi.org/10.5281/zenodo.1161724](http://doi.org/10.5281/zenodo.1161724)
 
 
 ## Contributing

--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -112,10 +112,8 @@ include("timesteppers.jl")
 include("diffusion.jl")
 
 # CUDA functionality
-if CUDA.functional()
-  @info "GPU functionality for FourierFlows is loaded"
-  include("CuFourierFlows.jl")
-end
+include("CuFourierFlows.jl")
+
 
 function __init__()
   threads = Threads.nthreads()


### PR DESCRIPTION
Up to now GPU functionality was only loaded if CUDA was enabled. But this was creating trouble because it was only done during first precompilation and if you happened to precompile on a machine without GPU or on a cluster on a login node that didn't see the GPU then GPU functionality was not loaded.

This was a leftover from an era when `using CUDA` would break on a machine without GPU. This era is long gone now. 

This PR loads GPU functionality regardless!

@liasiegelman I believe this will solve some of the problems both of us have had in the past.