### PR TITLE
Minor cleanup of timesteppers + fix bug in time stepper tests

### DIFF
--- a/src/FourierFlows.jl
+++ b/src/FourierFlows.jl
@@ -51,6 +51,7 @@ export
   FilteredForwardEulerTimeStepper,
   RK4TimeStepper,
   FilteredRK4TimeStepper,
+  LSRK54TimeStepper,
   ETDRK4TimeStepper,
   FilteredETDRK4TimeStepper,
   AB3TimeStepper,

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -111,18 +111,18 @@ function Problem(eqn::Equation, stepper, dt, grid::AbstractGrid{T},
 end
 
 show(io::IO, clock::FourierFlows.Clock) =
-     print(io, "Clock\n",
-               "  ├─── timestep dt: ", clock.dt, "\n",
-               "  ├────────── step: ", clock.step, "\n",
-               "  └──────── time t: ", clock.t)
+    print(io, "Clock\n",
+              "  ├─── timestep dt: ", clock.dt, "\n",
+              "  ├────────── step: ", clock.step, "\n",
+              "  └──────── time t: ", clock.t)
 
 show(io::IO, eqn::FourierFlows.Equation) =
-     print(io, "Equation\n",
-               "  ├──────── linear coefficients: L", "\n",
-               "  │                              ├───type: ", eltype(eqn.L), "\n",
-               "  │                              └───size: ", size(eqn.L), "\n",
-               "  ├───────────── nonlinear term: calcN!()", "\n",
-               "  └─── type of state vector sol: ", eqn.T)
+    print(io, "Equation\n",
+              "  ├──────── linear coefficients: L", "\n",
+              "  │                              ├───type: ", eltype(eqn.L), "\n",
+              "  │                              └───size: ", size(eqn.L), "\n",
+              "  ├───────────── nonlinear term: calcN!()", "\n",
+              "  └─── type of state vector sol: ", eqn.T)
 
 show(io::IO, problem::FourierFlows.Problem) =
     print(io, "Problem\n",

--- a/test/test_timesteppers.jl
+++ b/test/test_timesteppers.jl
@@ -39,7 +39,7 @@ dt = 1e-9 * 1/κ # make sure diffusive decay dynamics are resolved
 function constantdiffusiontest_stepforward(stepper, dev::Device=CPU(); kwargs...)
   nsteps = 1000
     
-  prob = construct_diffusion_problem(stepper, κ, dt; nx, Lx=2π, dev=CPU())
+  prob = construct_diffusion_problem(stepper, κ, dt; nx, Lx=2π, dev)
   c_initial, c_final, prob, t_compute = constantdiffusion_stepforward(prob, nsteps; c₀=0.01, σ=0.2, κ=κ)
   normmsg = "$stepper: relative error ="
   @printf("% 40s %.2e (%.3f s)\n", normmsg, norm(c_final-Array(prob.vars.c))/norm(c_final), t_compute)
@@ -50,7 +50,7 @@ end
 function varyingdiffusiontest_stepforward(stepper, dev::Device=CPU(); kwargs...)
   nsteps = 1000
   
-  prob = construct_diffusion_problem(stepper, κ*ones(nx), dt; nx=nx, Lx=2π, dev=CPU())
+  prob = construct_diffusion_problem(stepper, κ * ones(nx), dt; nx=nx, Lx=2π, dev)
   c_initial, c_final, prob, t_compute = constantdiffusion_stepforward(prob, nsteps; c₀=0.01, σ=0.2, κ=κ)
   normmsg = "$stepper: relative error ="
   @printf("% 40s %.2e (%.3f s)\n", normmsg, norm(c_final-Array(prob.vars.c))/norm(c_final), t_compute)
@@ -61,7 +61,7 @@ end
 function constantdiffusiontest_step_until(stepper, dev::Device=CPU(); kwargs...)
   t_final = 1000*dt + 1e-6/π # make sure t_final is not integer multiple of dt
   
-  prob = construct_diffusion_problem(stepper, κ, dt; nx, Lx=2π, dev=CPU())
+  prob = construct_diffusion_problem(stepper, κ, dt; nx, Lx=2π, dev)
   c_initial, c_final, prob, t_compute = constantdiffusion_step_until(prob, t_final; c₀=0.01, σ=0.2, κ=κ)
   normmsg = "$stepper: relative error ="
   @printf("% 40s %.2e (%.3f s)\n", normmsg, norm(c_final-Array(prob.vars.c))/norm(c_final), t_compute)

--- a/test/test_timesteppers.jl
+++ b/test/test_timesteppers.jl
@@ -40,7 +40,7 @@ function constantdiffusiontest_stepforward(stepper, dev::Device=CPU(); kwargs...
   nsteps = 1000
     
   prob = construct_diffusion_problem(stepper, κ, dt; nx, Lx=2π, dev)
-  c_initial, c_final, prob, t_compute = constantdiffusion_stepforward(prob, nsteps; c₀=0.01, σ=0.2, κ=κ)
+  c_initial, c_final, prob, t_compute = constantdiffusion_stepforward(prob, nsteps; c₀=0.01, σ=0.2, κ)
   normmsg = "$stepper: relative error ="
   @printf("% 40s %.2e (%.3f s)\n", normmsg, norm(c_final-Array(prob.vars.c))/norm(c_final), t_compute)
 
@@ -50,8 +50,8 @@ end
 function varyingdiffusiontest_stepforward(stepper, dev::Device=CPU(); kwargs...)
   nsteps = 1000
   
-  prob = construct_diffusion_problem(stepper, κ * ones(nx), dt; nx=nx, Lx=2π, dev)
-  c_initial, c_final, prob, t_compute = constantdiffusion_stepforward(prob, nsteps; c₀=0.01, σ=0.2, κ=κ)
+  prob = construct_diffusion_problem(stepper, κ * ones(nx), dt; nx, Lx=2π, dev)
+  c_initial, c_final, prob, t_compute = constantdiffusion_stepforward(prob, nsteps; c₀=0.01, σ=0.2, κ)
   normmsg = "$stepper: relative error ="
   @printf("% 40s %.2e (%.3f s)\n", normmsg, norm(c_final-Array(prob.vars.c))/norm(c_final), t_compute)
 
@@ -62,7 +62,7 @@ function constantdiffusiontest_step_until(stepper, dev::Device=CPU(); kwargs...)
   t_final = 1000*dt + 1e-6/π # make sure t_final is not integer multiple of dt
   
   prob = construct_diffusion_problem(stepper, κ, dt; nx, Lx=2π, dev)
-  c_initial, c_final, prob, t_compute = constantdiffusion_step_until(prob, t_final; c₀=0.01, σ=0.2, κ=κ)
+  c_initial, c_final, prob, t_compute = constantdiffusion_step_until(prob, t_final; c₀=0.01, σ=0.2, κ)
   normmsg = "$stepper: relative error ="
   @printf("% 40s %.2e (%.3f s)\n", normmsg, norm(c_final-Array(prob.vars.c))/norm(c_final), t_compute)
 


### PR DESCRIPTION
- Code cleanup in `timesteppers.jl`
- `export LSRK54TimeStepper`
- fix bug in `test_timesteppers.jl` that was forcing testing only on CPU