### PR TITLE
Add method for `device_array(::AbstractGrid)`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -301,3 +301,12 @@ device_array(::CPU) = Array
 device_array(::GPU) = CuArray
 device_array(::CPU, T, dim) = Array{T, dim}
 device_array(::GPU, T, dim) = CuArray{T, dim}
+
+"""
+    device_array(grid::AbstractGrid)
+    device_array(device::Device, T, dim)
+
+Return the proper array type according to the `grid`'s `device`, i.e., `Array` for CPU and
+`CuArray` for GPU.
+"""
+device_array(grid::AbstractGrid) = device_array(grid.device)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -230,6 +230,7 @@ for dev in devices
     @test test_supersize()
     @test test_device_array(dev)
     @test test_device_array_Tdim(dev, Float32, 2)
+    @test test_device_grid(dev)
 
     # Test on a rectangular grid
     nx, ny = 64, 128   # number of points

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -143,6 +143,11 @@ test_device_array(dev::Device) =
 test_device_array_Tdim(dev::Device, T=Float64, dim=1) = 
   dev==CPU() ? device_array(dev, T, dim) <: Array{T, dim} : device_array(dev, T, dim) <: CuArray{T, dim}
 
+function test_device_grid(dev::Device)
+  grid = TwoDGrid(dev; nx=8, Lx=2π)
+  return dev==CPU() ? device_array(grid) == Array : device_array(grid) == CuArray
+end
+
 function test_ongrid(dev::Device)
   nx, ny, nz = 6, 8, 10
   Lx, Ly, Lz = 2π, 2.0, 3.0


### PR DESCRIPTION
This PR adds a method for `device_array` based on `grid`. 

(Inspired by discussion in https://github.com/FourierFlows/GeophysicalFlows.jl/discussions/311)

cc @chowland